### PR TITLE
Resolve chromium communication disconnects

### DIFF
--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -41,7 +41,7 @@ class Connection(EventEmitter):
         self.connection: CDPSession
         self._connected = False
         self._ws = websockets.client.connect(
-            self._url, max_size=None, loop=self._loop)
+            self._url, max_size=None, loop=self._loop, ping_interval=None, ping_timeout=None)
         self._recv_fut = self._loop.create_task(self._recv_loop())
         self._closeCallback: Optional[Callable[[], None]] = None
 


### PR DESCRIPTION
> I randomly (but quite frequently) get this error when I try to crawl several pages of a website :
> Task exception was never retrieved future: <Task finished coro=<CDPSession.send() done, defined at /Users/user/.virtualenvs/project/lib/python3.6/site-packages/pyppeteer/connection.py:180> exception=NetworkError('Protocol Error: Unknown event id: 25 None',)>

```python
Traceback (most recent call last): File "/Users/user/.virtualenvs/project/lib/python3.6/site-packages/pyppeteer/connection.py", line 200, in send return await callback
```

> An idea where this error could come from ?  
> Also, this does not seem to affect the scenario but it looks like tasks are not handled the way asyncio expects in the connection class.

By: https://github.com/PCXDME
https://github.com/miyakogi/pyppeteer/issues/159
