### PR TITLE
Fixes the typing hint for the return of Page.cookies()

### DIFF
--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -470,7 +470,7 @@ class Page(EventEmitter):
     #: alias to :meth:`xpath`
     Jx = xpath
 
-    async def cookies(self, *urls: str) -> dict:
+    async def cookies(self, *urls: str) -> List[Dict[str, Union[str, int, bool]]]:
         """Get cookies.
 
         If no URLs are specified, this method returns cookies for the current


### PR DESCRIPTION
Proposed by [grammy-jiang](https://github.com/miyakogi/pyppeteer/commits?author=grammy-jiang)
[Issue](https://github.com/miyakogi/pyppeteer/pull/282/commits/e32a7188ce720b4ee8369f28b00220e545f6beec)