### PR TITLE
Migrate browser module to 2.1.1

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -161,6 +161,14 @@ class TestBrowser(unittest.TestCase):
         self.assertEqual(await page.evaluate('2 * 3'), 6)
         await browserWithExtension.close()
 
+    @unittest.skipIf('CI' in os.environ, 'skip in-browser test on CI server')
+    @sync
+    async def test_waitForTarget(self):
+        browser = await launch(**DEFAULT_OPTIONS)
+        self.assertIsNotNone(await browser.waitForTarget(lambda target: target))
+        with self.assertRaises(asyncio.exceptions.TimeoutError):
+            await browser.waitForTarget(lambda target: False, timeout=100),
+
 
 class TestPageClose(BaseTestCase):
     @sync


### PR DESCRIPTION
This PR implements feature parity with 2.1.1 puppeteer api for browser module: 
https://github.com/puppeteer/puppeteer/blob/eec43252fa60f0b018a252be5a45e5d2d1fd570e/lib/Browser.js
- add defaultBrowserContext property
- add target property
- add WaitForTarget method
- migrate to asyncio.gather where possible
- encourage explicit kwargs
- reduce redundant code