### PR TITLE
fully implement puppeteer@2.1.1/lib/Multimap.js

### DIFF
--- a/pyppeteer/multimap.py
+++ b/pyppeteer/multimap.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-"""Multimap module."""
+"""
+Multimap module.
 
-from collections import OrderedDict
-from typing import Any, List, Optional
+puppeteer equivalent: lib/Multimap.js
+"""
+
+
+from typing import Any, List, Optional, Dict
 
 
 class Multimap(object):
@@ -13,7 +17,7 @@ class Multimap(object):
     def __init__(self) -> None:
         """Make new multimap."""
         # maybe defaultdict(set) is better
-        self._map: OrderedDict[Optional[str], List[Any]] = OrderedDict()
+        self._map: Dict[Optional[str], List[Any]] = {}
 
     def set(self, key: Optional[str], value: Any) -> None:
         """Set value."""


### PR DESCRIPTION
#### <s>I think it should be noted that there are no usages it this code right now in either pyppeter or puppeteer codebase, and we should consider dropping it completely. IIRC, Multimap.js was last modified in 2017. Since this module is fairly trivial, I think the trade off of a cleaner working space outweighs the possibility that this module's user is realized.</s>

I was looking for usages wrong, it's used in tests