### PR TITLE
add models module, use it

### DIFF
--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -14,6 +14,9 @@ __version__ = '0.2.2'
 __chromium_revision__ = '722234'
 __base_puppeteer_version__ = 'v1.6.0'
 __pyppeteer_home__ = os.environ.get('PYPPETEER_HOME', AppDirs('pyppeteer').user_data_dir)  # type: str
+
+from pyppeteer.models import LaunchOptions, ChromeArgOptions, BrowserOptions
+
 DEBUG = False
 
 # Setup root logger
@@ -26,7 +29,7 @@ _log_handler.setLevel(logging.DEBUG)
 _logger.addHandler(_log_handler)
 _logger.propagate = False
 
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 from pyppeteer.browser import Browser
 from pyppeteer.device_descriptors import devices
@@ -53,12 +56,12 @@ class Pyppeteer:
     def devices(self):
         return devices
 
-    async def launch(self, options: Dict[str, Any] = None) -> Browser:
+    async def launch(self, options: Union[LaunchOptions, ChromeArgOptions, BrowserOptions]) -> Browser:
         if not self.productName and options:
             self.productName = options.get('product')
         return await self._launcher.launch(options)
 
-    def connect(self, options: Any):
+    def connect(self, options: Union[LaunchOptions, ChromeArgOptions, BrowserOptions]):
         return self._launcher.connect(options)
 
     @property

--- a/pyppeteer/browser.py
+++ b/pyppeteer/browser.py
@@ -12,6 +12,7 @@ from pyee import AsyncIOEventEmitter
 from pyppeteer.connection import Connection
 from pyppeteer.errors import BrowserError
 from pyppeteer.events import Events
+from pyppeteer.models import Viewport
 from pyppeteer.target import Target
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ class Browser(AsyncIOEventEmitter):
         connection: Connection,
         contextIds: List[str],
         ignoreHTTPSErrors: bool,
-        defaultViewport: Optional[Dict],
+        defaultViewport: Viewport,
         process: Optional[Popen] = None,
         closeCallback: Callable[[], Awaitable[None]] = None,
         **kwargs: Any,
@@ -125,7 +126,7 @@ class Browser(AsyncIOEventEmitter):
         connection: Connection,
         contextIds: List[str],
         ignoreHTTPSErrors: bool,
-        defaultViewport: Optional[Dict],
+        defaultViewport: Viewport,
         process: Optional[Popen] = None,
         closeCallback: Callable[[], Awaitable[None]] = None,
         **kwargs: Any,

--- a/pyppeteer/browser_fetcher.py
+++ b/pyppeteer/browser_fetcher.py
@@ -44,10 +44,10 @@ class RevisionInfo(TypedDict):
     revision: str
 
 
-class BrowserFetcherOptions(TypedDict, total=False):
-    platform: Platforms
-    path: Path
-    host: str
+# class BrowserFetcherOptions(TypedDict, total=False):
+#     platform: Platforms
+#     path: Path
+#     host: str
 
 
 DEFAULT_DOWNLOAD_HOST = 'https://storage.googleapis.com'

--- a/pyppeteer/browser_fetcher.py
+++ b/pyppeteer/browser_fetcher.py
@@ -44,10 +44,6 @@ class RevisionInfo(TypedDict):
     revision: str
 
 
-# class BrowserFetcherOptions(TypedDict, total=False):
-#     platform: Platforms
-#     path: Path
-#     host: str
 
 
 DEFAULT_DOWNLOAD_HOST = 'https://storage.googleapis.com'

--- a/pyppeteer/browser_fetcher.py
+++ b/pyppeteer/browser_fetcher.py
@@ -44,7 +44,7 @@ class RevisionInfo(TypedDict):
     revision: str
 
 
-class BrowserOptions(TypedDict, total=False):
+class BrowserFetcherOptions(TypedDict, total=False):
     platform: Platforms
     path: Path
     host: str

--- a/pyppeteer/device_descriptors.py
+++ b/pyppeteer/device_descriptors.py
@@ -2,7 +2,9 @@ from typing import Dict, Union
 
 # noqa
 # pragma: no cover
-devices: Dict[str, Dict[str, Union[str, Dict[str, Union[bool, int]]]]] = {
+from pyppeteer.models import Viewport
+
+devices: Dict[str, Dict[str, Union[str, Viewport]]] = {
     "Blackberry PlayBook": {
         "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+",
         "viewport": {

--- a/pyppeteer/emulation_manager.py
+++ b/pyppeteer/emulation_manager.py
@@ -5,6 +5,7 @@
 import asyncio
 
 from pyppeteer.connection import CDPSession
+from pyppeteer.models import Viewport
 
 
 class EmulationManager:
@@ -17,7 +18,7 @@ class EmulationManager:
         self._hasTouch = False
         self._emulatingMobile = False
 
-    async def emulateViewport(self, viewport: dict) -> bool:
+    async def emulateViewport(self, viewport: Viewport) -> bool:
         """
         Evaluate viewport.
         :param viewport: dictionary which supports keys: isMobile, width, height,

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -19,6 +19,7 @@ from pyppeteer.browser import Browser
 from pyppeteer.connection import Connection
 from pyppeteer.errors import BrowserError
 from pyppeteer.helper import debugError
+from pyppeteer.models import LaunchOptions, Viewport, ChromeArgOptions, BrowserOptions
 from pyppeteer.util import get_free_port
 from pyppeteer.websocket_transport import WebsocketTransport
 

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -14,6 +14,7 @@ from typing import Dict, Sequence, Union, List, Optional, Awaitable, Any, Tuple
 from urllib.error import URLError
 from urllib.request import urlopen
 
+from pyppeteer import BrowserFetcher
 from pyppeteer.browser import Browser
 from pyppeteer.connection import Connection
 from pyppeteer.errors import BrowserError
@@ -30,39 +31,6 @@ except ImportError:
     from typing_extensions import TypedDict, Literal
 
 logger = logging.getLogger(__name__)
-
-
-class ChromeArgOptions(TypedDict, total=False):
-    headless: bool
-    args: Sequence[str]
-    userDataDir: str
-    devtools: bool
-
-
-class LaunchOptions(TypedDict, total=False):
-    executablePath: str
-    ignoreDefaultArgs: Union[Literal[False], Sequence[str]]
-    handleSIGINT: bool
-    handleSIGTERM: bool
-    handleSIGHUP: bool
-    timeout: float
-    dumpio: bool
-    env: Dict[str, Union[str, bool]]
-
-
-class Viewport(TypedDict, total=False):
-    width: float
-    height: float
-    deviceScaleFactor: float
-    isMobile: bool
-    isLandscape: bool
-    hasTouch: bool
-
-
-class BrowserOptions(TypedDict, total=False):
-    ignoreHTTPSErrors: bool
-    defaultViewport: Viewport
-    slowMo: float
 
 
 def _restore_default_signal_handlers():

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -551,7 +551,7 @@ class FirefoxLauncher(BaseBrowserLauncher):
             connection = await runner.setupConnection(
                 usePipe=pipe, timeout=timeout, slowMo=slowMo, preferredRevision=self.preferredRevision,
             )
-            browser = Browser.create(
+            browser = await Browser.create(
                 connection=connection,
                 contextIds=[],
                 ignoreHTTPSErrors=ignoreHTTPSErrors,

--- a/pyppeteer/models.py
+++ b/pyppeteer/models.py
@@ -1,0 +1,38 @@
+"""Type definitions for widely used types"""
+try:
+    from typing import TypedDict, Sequence, Union, Literal, Dict
+except ImportError:
+    from typing import TypedDict
+
+
+class Viewport(TypedDict, total=False):
+    width: float
+    height: float
+    deviceScaleFactor: float
+    isMobile: bool
+    isLandscape: bool
+    hasTouch: bool
+
+
+class BrowserOptions(TypedDict, total=False):
+    ignoreHTTPSErrors: bool
+    defaultViewport: Viewport
+    slowMo: float
+
+
+class ChromeArgOptions(TypedDict, total=False):
+    headless: bool
+    args: Sequence[str]
+    userDataDir: str
+    devtools: bool
+
+
+class LaunchOptions(TypedDict, total=False):
+    executablePath: str
+    ignoreDefaultArgs: Union[Literal[False], Sequence[str]]
+    handleSIGINT: bool
+    handleSIGTERM: bool
+    handleSIGHUP: bool
+    timeout: float
+    dumpio: bool
+    env: Dict[str, Union[str, bool]]

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -29,6 +29,7 @@ from pyppeteer.execution_context import JSHandle
 from pyppeteer.helper import debugError
 from pyppeteer.input import Keyboard, Mouse, Touchscreen
 from pyppeteer.jshandle import ElementHandle, createJSHandle
+from pyppeteer.models import Viewport
 from pyppeteer.network_manager import Response, Request
 from pyppeteer.timeout_settings import TimeoutSettings
 from pyppeteer.tracing import Tracing
@@ -71,7 +72,7 @@ class Page(AsyncIOEventEmitter):
         client: CDPSession,
         target: 'Target',
         ignoreHTTPSErrors: bool,
-        defaultViewport: Optional[Dict],
+        defaultViewport: Viewport,
         screenshotTaskQueue: list = None,
     ) -> 'Page':
         """Async function which makes new page object."""
@@ -101,7 +102,7 @@ class Page(AsyncIOEventEmitter):
         self._pageBindings: Dict[str, Callable[..., Any]] = dict()
         self._coverage = Coverage(client)
         self._javascriptEnabled = True
-        self._viewport: Optional[Dict] = None
+        self._viewport: Viewport = None
 
         if screenshotTaskQueue is None:
             screenshotTaskQueue = []
@@ -937,7 +938,7 @@ class Page(AsyncIOEventEmitter):
         """Bring page to front (activate tab)."""
         await self._client.send('Page.bringToFront')
 
-    async def emulate(self, viewport: Dict[str, Union[int, str, bool]], userAgent: str,) -> None:
+    async def emulate(self, viewport: Viewport, userAgent: str,) -> None:
         """Emulate given device metrics and user agent.
 
         This method is a shortcut for calling two methods:
@@ -1012,7 +1013,7 @@ class Page(AsyncIOEventEmitter):
                 raise PageError(f'Invalid timezone ID: {timezoneId}')
             raise e
 
-    async def setViewport(self, viewport: dict) -> None:
+    async def setViewport(self, viewport: Viewport) -> None:
         """Set viewport.
 
         Available options are:

--- a/pyppeteer/target.py
+++ b/pyppeteer/target.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List, Optional, Awaitable, TYPE_CHECKING
 
 from pyppeteer.connection import CDPSession
 from pyppeteer.events import Events
+from pyppeteer.models import Viewport
 from pyppeteer.page import Page
 from pyppeteer.worker import Worker
 
@@ -24,7 +25,7 @@ class Target:
         browserContext: 'BrowserContext',
         sessionFactory: Callable[[], Awaitable[CDPSession]],
         ignoreHTTPSErrors: bool,
-        defaultViewport: Optional[Dict],
+        defaultViewport: Viewport,
         screenshotTaskQueue: List,
         loop: asyncio.AbstractEventLoop,
     ) -> None:


### PR DESCRIPTION
This PR add `models.py` and uses it. Not every eligible complex type was considered for this module, as this PR aims only to establish it's existence and valid use cases.