### PR TITLE
reimplement both the Response and Request classes in network_manager.py

### DIFF
--- a/pyppeteer/lifecycle_watcher.py
+++ b/pyppeteer/lifecycle_watcher.py
@@ -8,12 +8,12 @@ puppeteer equivalent: lib/LifecycleWatcher.js
 """
 
 import asyncio
-from asyncio import FIRST_COMPLETED, Future
+from asyncio import Future
 from functools import partial
-from typing import Awaitable, Dict, List, Union, Optional, TYPE_CHECKING, Literal
+from typing import Awaitable, List, Union, Optional, TYPE_CHECKING, Literal, Any
 
 from pyppeteer import helper
-from pyppeteer.errors import TimeoutError, BrowserError, PageError, DeprecationError
+from pyppeteer.errors import TimeoutError, BrowserError, PageError
 from pyppeteer.events import Events
 from pyppeteer.network_manager import Request
 
@@ -35,11 +35,11 @@ class LifecycleWatcher:
     """LifecycleWatcher class."""
 
     def __init__(
-        self,
-        frameManager: 'FrameManager',
-        frame: 'Frame',
-        timeout: int,
-        waitUntil: Union[WaitTargets, List[WaitTargets]] = 'load',
+            self,
+            frameManager: 'FrameManager',
+            frame: 'Frame',
+            timeout: int,
+            waitUntil: Union[WaitTargets, List[WaitTargets]] = 'load',
     ) -> None:
         """Make new LifecycleWatcher"""
         self._expectedLifecycle: List[str] = []
@@ -72,8 +72,9 @@ class LifecycleWatcher:
             helper.addEventListener(
                 self._frameManager, Events.FrameManager.FrameNavigatedWithinDocument, self._navigatedWithinDocument,
             ),
-            helper.addEventListener(self._frameManager, Events.FrameManager.FrameDetached, self._onFrameDetached,),
-            helper.addEventListener(self._frameManager.networkManager, Events.NetworkManager.Request, self._onRequest,),
+            helper.addEventListener(self._frameManager, Events.FrameManager.FrameDetached, self._onFrameDetached, ),
+            helper.addEventListener(self._frameManager.networkManager, Events.NetworkManager.Request,
+                                    self._onRequest, ),
         ]
         self.loop = self._frameManager._client.loop
 
@@ -103,7 +104,7 @@ class LifecycleWatcher:
         return self._newDocumentNavigationFuture
 
     def _onRequest(self, request: Request) -> None:
-        if request.frame == self._frame and request.isNavigationRequest():
+        if request.frame == self._frame and request.isNavigationRequest:
             self._navigationRequest = request
 
     def _onFrameDetached(self, frame: 'Frame' = None) -> None:
@@ -149,14 +150,13 @@ class LifecycleWatcher:
         if not self._checkLifecycle(self._frame, self._expectedLifecycle):
             return
         # python can set future only once but this might be called multiple times
-        if not self._lifecycleFuture.done():
-            self._lifecycleFuture.set_result(None)
+        safe_future_set_result(self._lifecycleFuture, None)
         if self._frame._loaderId == self._initialLoaderId and not self._hasSameDocumentNavigation:
             return
         if self._hasSameDocumentNavigation:
-            self._sameDocumentNavigationFuture.set_result(None)
+            safe_future_set_result(self._sameDocumentNavigationFuture, None)
         if self._frame._loaderId != self._initialLoaderId:
-            self._newDocumentNavigationFuture.set_result(None)
+            safe_future_set_result(self._newDocumentNavigationFuture, None)
 
     def _checkLifecycle(self, frame: 'Frame', expectedLifecycle: List[str]) -> bool:
         for event in expectedLifecycle:
@@ -174,3 +174,8 @@ class LifecycleWatcher:
                 fut.cancel()
             except AttributeError:
                 continue
+
+
+def safe_future_set_result(fut: Future, res: Any):
+    if not fut.done():
+        fut.set_result(res)

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -363,7 +363,7 @@ class Request:
 
         ``redirectChain`` is shared between all the requests of the same chain.
         """
-        return self._redirectChain
+        return self._redirectChain.copy()
 
     @property
     def failure(self) -> Optional[Dict[str, str]]:

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -804,7 +804,7 @@ class Request2:
         'failed': 'Failed',
     }
 
-    def __init__(self, client: CDPSession, frame: Frame, interceptionId: str, allowInterception: bool,
+    def __init__(self, client: CDPSession, frame: 'Frame', interceptionId: str, allowInterception: bool,
                  event: Dict[str, Any],
                  redirectChain: List['Request2']):
         self._client = client

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -51,7 +51,7 @@ class NetworkManager(AsyncIOEventEmitter):
         self._client.on('Network.loadingFinished', self._onLoadingFinished)
         self._client.on('Network.loadingFailed', self._onLoadingFailed)
 
-    async def initialize(self):
+    async def initialize(self) -> None:
         await self._client.send('Network.enable')
         if self._ignoreHTTPSErrors:
             await self._client.send('Security.setIgnoreCertificateErrors', {'ignore': True})
@@ -110,7 +110,7 @@ class NetworkManager(AsyncIOEventEmitter):
         else:
             await asyncio.gather(self._updateProtocolCacheDisabled(), self._client.send('Fetch.disable'))
 
-    async def _updateProtocolCacheDisabled(self):
+    async def _updateProtocolCacheDisabled(self) -> None:
         await self._client.send(
             'Network.setCacheDisabled',
             {'cacheDisabled': self._userCacheDisabled or self._protocolRequestInterceptionEnabled},
@@ -129,7 +129,7 @@ class NetworkManager(AsyncIOEventEmitter):
             return
         self._onRequest(event, None)
 
-    async def _onAuthRequired(self, event: Dict):
+    async def _onAuthRequired(self, event: Dict) -> None:
         response = 'Default'
         requestId = event.get('requestId')
         if requestId in self._attemptedAuthentications:
@@ -147,7 +147,7 @@ class NetworkManager(AsyncIOEventEmitter):
             },
         )
 
-    async def _onRequestPaused(self, event: Dict):
+    async def _onRequestPaused(self, event: Dict) -> None:
         if self._userRequestInterceptionEnabled and self._protocolRequestInterceptionEnabled:
             await self._client.send('Fetch.continueRequest', {'requestId': event.get('requestId')})
         requestId = event.get('networkId')
@@ -455,7 +455,7 @@ class Request:
             # or the page was closed. We should tolerate these errors.
             debugError(logger, str(e))
 
-    async def abort(self, errorCode: str = 'failed'):
+    async def abort(self, errorCode: str = 'failed') -> None:
         """Abort request.
 
         To use this, request interception should be enabled by
@@ -548,7 +548,7 @@ class Response:
             self._securityDetails = None
 
     @property
-    def remoteAddress(self):
+    def remoteAddress(self) -> Dict[str, str]:
         return self._remoteAddress
 
     @property
@@ -568,7 +568,7 @@ class Response:
         return self._statusText
 
     @property
-    def headers(self) -> Dict:
+    def headers(self) -> Dict[str,str]:
         """
         Return dictionary of HTTP headers of this response.
         All header names are lower-case.
@@ -576,7 +576,7 @@ class Response:
         return self._headers
 
     @property
-    def securityDetails(self):
+    def securityDetails(self) -> Optional[SecurityDetails]:
         """Return security details associated with this response.
 
         Security details if the response was received over the secure
@@ -601,22 +601,22 @@ class Response:
             return self._contentFuture
 
     @property
-    async def text(self):
+    async def text(self) -> str:
         """Text representation of response body."""
         return (await self.buffer()).decode('utf-8')
 
     @property
-    async def json(self):
+    async def json(self) -> Dict[str, Any]:
         """JSON representation of response body."""
         return json.loads(await self.text)
 
     @property
-    def request(self):
+    def request(self) -> 'Request':
         """matching :class:`Request` object."""
         return self._request
 
     @property
-    def fromCache(self):
+    def fromCache(self) -> bool:
         """
         Return ``True`` if the response was served from cache.
         Here `cache` is either the browser's disk cache or memory cache.
@@ -624,13 +624,13 @@ class Response:
         return self._fromDiskCache or self._request._fromMemoryCache
 
     @property
-    def fromServiceWorker(self):
+    def fromServiceWorker(self) -> bool:
         """Return ``True`` if the response was served by a service worker."""
         return self._fromServiceWorker
 
     @property
-    def frame(self):
-        return self._request.frame()
+    def frame(self) -> Optional['Frame']:
+        return self._request.frame
 
 
 class SecurityDetails:

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -576,7 +576,7 @@ class Response:
         return self._headers
 
     @property
-    def securityDetails(self) -> Optional[SecurityDetails]:
+    def securityDetails(self) -> Optional['SecurityDetails']:
         """Return security details associated with this response.
 
         Security details if the response was received over the secure

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -82,7 +82,7 @@ class NetworkManager(AsyncIOEventEmitter):
         self._offline = value
         await self._client.send(
             'Network.emulateNetworkConditions',
-            {'offline': self._offline, 'latency': 0, 'downloadThroughput': -1, 'uploadThroughput': -1, },
+            {'offline': self._offline, 'latency': 0, 'downloadThroughput': -1, 'uploadThroughput': -1,},
         )
 
     async def setUserAgent(self, userAgent: str) -> None:
@@ -144,7 +144,7 @@ class NetworkManager(AsyncIOEventEmitter):
             'Fetch.continueWithAuth',
             {
                 'requestId': requestId,
-                'authChallengeResponse': {"response": response, "username": username, "password": password, },
+                'authChallengeResponse': {"response": response, "username": username, "password": password,},
             },
         )
 
@@ -189,13 +189,13 @@ class NetworkManager(AsyncIOEventEmitter):
         resp = Response(self._client, request, **responsePayload)
 
     def _handleRequestRedirect(
-            self,
-            request: 'Request',
-            status: int,
-            headers: Dict,
-            fromDiskCache: bool,
-            fromServiceWorker: bool,
-            securityDetails: Dict = None,
+        self,
+        request: 'Request',
+        status: int,
+        headers: Dict,
+        fromDiskCache: bool,
+        fromServiceWorker: bool,
+        securityDetails: Dict = None,
     ) -> None:
         response = Response2(
             client=self._client,
@@ -255,33 +255,14 @@ class NetworkManager(AsyncIOEventEmitter):
 
 
 class Request:
-    """Request class.
-
-    Whenever the page sends a request, such as for a network resource, the
-    following events are emitted by pyppeteer's page:
-
-    - ``'request'``: emitted when the request is issued by the page.
-    - ``'response'``: emitted when/if the response is received for the request.
-    - ``'requestfinished'``: emitted when the response body is downloaded and
-      the request is complete.
-
-    If request fails at some point, then instead of ``'requestfinished'`` event
-    (and possibly instead of ``'response'`` event), the ``'requestfailed'``
-    event is emitted.
-
-    If request gets a ``'redirect'`` response, the request is successfully
-    finished with the ``'requestfinished'`` event, and a new request is issued
-    to a redirect url.
-    """
-
     def __init__(
-            self,
-            client: CDPSession,
-            frame: 'Frame',
-            interceptionId: Optional[str],
-            allowInterception: bool,
-            event: dict,
-            redirectChain: List['Request'],
+        self,
+        client: CDPSession,
+        frame: 'Frame',
+        interceptionId: Optional[str],
+        allowInterception: bool,
+        event: dict,
+        redirectChain: List['Request'],
     ) -> None:
         self._client = client
         self._requestId = event['requestId']
@@ -503,9 +484,9 @@ class Request:
         """
         if self._url.startswith('data:'):
             return
-        errorReason = errorReasons[errorCode]
-        if not errorReason:
-            raise NetworkError('Unknown error code: {}'.format(errorCode))
+        # errorReason = errorReasons[errorCode]
+        # if not errorReason:
+        #     raise NetworkError('Unknown error code: {}'.format(errorCode))
         if not self._allowInterception:
             raise NetworkError('Request interception is not enabled.')
         if self._interceptionHandled:
@@ -519,23 +500,21 @@ class Request:
             debugError(logger, e)
 
 
-
-
 class Response(object):
     """Response class represents responses which are received by ``Page``."""
 
     def __init__(
-            self,
-            client: CDPSession,
-            request: Request,
-            status: int,
-            headers: Dict[str, str],
-            fromDiskCache: bool,
-            fromServiceWorker: bool,
-            securityDetails: Dict = None,
-            remoteIpAddress: str = '',
-            remotePort: str = '',
-            statusText: str = '',
+        self,
+        client: CDPSession,
+        request: Request,
+        status: int,
+        headers: Dict[str, str],
+        fromDiskCache: bool,
+        fromServiceWorker: bool,
+        securityDetails: Dict = None,
+        remoteIpAddress: str = '',
+        remotePort: str = '',
+        statusText: str = '',
     ) -> None:
         self._client = client
         self._request = request
@@ -744,21 +723,19 @@ class Response2:
     def securityDetails(self):
         return self._securityDetails
 
-    async def buffer(self):
+    def buffer(self) -> Awaitable[bytes]:
         # todo: verify
         if self._contentFuture is None:
             async def buffer_read():
-                self._contentFuture = await self._bodyLoadedFuture
-                response = await self._client.send(
-                    'Network.getResponseBody',
-                    {'requestId': self._request._requestId}
-                )
+                await self._bodyLoadedFuture
+                response = await self._client.send('Network.getResponseBody', {'requestId': self._request._requestId})
                 body = await response.get('body', b'')
                 if response.get('base64Encoded'):
                     return base64.b64decode(body)
                 return body
 
-            return self._client.loop.create_task(buffer_read())
+            self._contentFuture = self._client.loop.create_task(buffer_read())
+            return self._contentFuture
 
     @property
     async def text(self):
@@ -787,6 +764,25 @@ class Response2:
 
 
 class Request2:
+    """Request class.
+
+    Whenever the page sends a request, such as for a network resource, the
+    following events are emitted by pyppeteer's page:
+
+    - ``'request'``: emitted when the request is issued by the page.
+    - ``'response'``: emitted when/if the response is received for the request.
+    - ``'requestfinished'``: emitted when the response body is downloaded and
+      the request is complete.
+
+    If request fails at some point, then instead of ``'requestfinished'`` event
+    (and possibly instead of ``'response'`` event), the ``'requestfailed'``
+    event is emitted.
+
+    If request gets a ``'redirect'`` response, the request is successfully
+    finished with the ``'requestfinished'`` event, and a new request is issued
+    to a redirect url.
+    """
+
     _errorReasons = {
         'aborted': 'Aborted',
         'accessdenied': 'AccessDenied',
@@ -804,9 +800,15 @@ class Request2:
         'failed': 'Failed',
     }
 
-    def __init__(self, client: CDPSession, frame: 'Frame', interceptionId: str, allowInterception: bool,
-                 event: Dict[str, Any],
-                 redirectChain: List['Request2']):
+    def __init__(
+        self,
+        client: CDPSession,
+        frame: 'Frame',
+        interceptionId: str,
+        allowInterception: bool,
+        event: Dict[str, Any],
+        redirectChain: List['Request2'],
+    ):
         self._client = client
         self._requestId = event.get('requestId')
         self._isNavigationRequest = self._requestId == event.get('loaderId') and event['type'] == 'Document'
@@ -821,8 +823,8 @@ class Request2:
         self._resourceType = request_event['type'].lower()
         self._method = request_event['method']
         self._postData = request_event.get('postData')
-        self._frame = frame;
-        self._redirectChain = redirectChain;
+        self._frame = frame
+        self._redirectChain = redirectChain
         self._headers = {k.lower(): v for k, v in request_event.get('headers', {}).items()}
 
         self._fromMemoryCache = False
@@ -891,8 +893,7 @@ class Request2:
         self._interceptionHandled = True
 
         if isinstance(response.get('body'), str):
-            # todo: buffer stuff here
-            responseBody = None
+            responseBody: bytes = response['body'].encode('utf-9')
         else:
             responseBody = response.get('body')
 
@@ -902,14 +903,16 @@ class Request2:
         if responseBody and 'content-length' not in responseHeaders:
             responseHeaders['content-length'] = str(len(responseBody))
         try:
-            await self._client.send('Fetch.fulfillRequest',
-                                    {
-                                        'requestId': self._interceptionId,
-                                        'responseCode': response.get('status', 200),
-                                        'responsePhrase': STATUS_TEXTS[int(response.get('status', 200))],
-                                        'responseHeaders': headersArray(responseHeaders),
-                                        'body': base64.b64encode(responseBody) if responseBody else None,
-                                    })
+            await self._client.send(
+                'Fetch.fulfillRequest',
+                {
+                    'requestId': self._interceptionId,
+                    'responseCode': response.get('status', 200),
+                    'responsePhrase': STATUS_TEXTS[int(response.get('status', 200))],
+                    'responseHeaders': headersArray(responseHeaders),
+                    'body': base64.b64encode(responseBody).decode('ascii') if responseBody else None,
+                },
+            )
         except Exception as e:
             # todo: find out what error is raised from here
             # In certain cases, protocol will return error if the request was already canceled

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -30,7 +30,7 @@ from pyppeteer.helper import debugError
 from pyppeteer.input import Keyboard, Mouse, Touchscreen
 from pyppeteer.jshandle import ElementHandle, createJSHandle
 from pyppeteer.models import Viewport
-from pyppeteer.network_manager import Response, Request, Response2
+from pyppeteer.network_manager import Response, Request, Response
 from pyppeteer.timeout_settings import TimeoutSettings
 from pyppeteer.tracing import Tracing
 from pyppeteer.worker import Worker
@@ -736,7 +736,7 @@ class Page(AsyncIOEventEmitter):
 
     async def goto(
         self, url: str, referer: str = None, timeout: float = None, waitUntil: Union[str, List[str]] = None,
-    ) -> Optional[Response2]:
+    ) -> Optional[Response]:
         """Go to the ``url``.
 
         :arg string url: URL to navigate page to. The url should include

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -30,7 +30,7 @@ from pyppeteer.helper import debugError
 from pyppeteer.input import Keyboard, Mouse, Touchscreen
 from pyppeteer.jshandle import ElementHandle, createJSHandle
 from pyppeteer.models import Viewport
-from pyppeteer.network_manager import Response, Request
+from pyppeteer.network_manager import Response, Request, Response2
 from pyppeteer.timeout_settings import TimeoutSettings
 from pyppeteer.tracing import Tracing
 from pyppeteer.worker import Worker
@@ -736,7 +736,7 @@ class Page(AsyncIOEventEmitter):
 
     async def goto(
         self, url: str, referer: str = None, timeout: float = None, waitUntil: Union[str, List[str]] = None,
-    ) -> Optional[Response]:
+    ) -> Optional[Response2]:
         """Go to the ``url``.
 
         :arg string url: URL to navigate page to. The url should include


### PR DESCRIPTION
This is a WIP re-implementation of the `Response` and `Request` classes in `network_manager.py`. The reason being that the old implementation was outdated and incompatible - this PR aims to fix that. This is one of the main (known) blockers of #16. 

As this is a WIP PR until marked ready for review, there are still a few things that need doing before it'd be sensible to merge:

- [x] implement buffer operations (see old implemenatations in old `Re(sponse|quest)` classes (main blocker)
- [x] replace every `Response` instance with `Response2`, then rename ` Response2` to `Response`
- [x] replace every `Request` instance with `Request2`, then rename ` Request2` to `Request`
