### PR TITLE
Improve WebsocketTransport.create

### DIFF
--- a/pyppeteer/connection/__init__.py
+++ b/pyppeteer/connection/__init__.py
@@ -8,6 +8,7 @@ from pyee import AsyncIOEventEmitter
 
 from pyppeteer.errors import NetworkError
 from pyppeteer.events import Events
+from pyppeteer.helper import async_closing
 from pyppeteer.websocket_transport import WebsocketTransport
 
 try:
@@ -80,7 +81,7 @@ class Connection(AsyncIOEventEmitter):
         return self._url
 
     async def _recv_loop(self) -> None:
-        async with self._transport as transport_connection:
+        async with async_closing(self._transport) as transport_connection:
             self._connected = True
             self.connection = transport_connection
             self.connection.onmessage = lambda msg: self._onMessage(msg)

--- a/pyppeteer/helper.py
+++ b/pyppeteer/helper.py
@@ -15,6 +15,12 @@ import pyppeteer
 from pyppeteer.connection import CDPSession
 from pyppeteer.errors import ElementHandleError, TimeoutError
 
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    from async_generator import asynccontextmanager
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -159,6 +165,14 @@ def waitForEvent(
             eventTimeout.cancel()
 
     return promise
+
+
+@asynccontextmanager
+async def async_closing(thing_to_close):
+    try:
+        yield thing_to_close
+    finally:
+        await thing_to_close.close()
 
 
 def get_positive_int(obj: dict, name: str) -> int:

--- a/pyppeteer/websocket_transport.py
+++ b/pyppeteer/websocket_transport.py
@@ -15,38 +15,20 @@ class WebsocketTransport:
         self.onclose: Optional[Callable[[], Any]] = None
         self.ws = ws
 
-    def __aenter__(self):
-        return self
-
-    def __aexit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-
     @classmethod
-    @asynccontextmanager
     async def create(cls, uri: str, loop: asyncio.AbstractEventLoop = None) -> 'WebsocketTransport':
-        try:
-            instance = cls(
-                await connect(
-                    uri=uri,
-                    ping_interval=None,  # chrome doesn't respond to pings
-                    max_size=256 * 1024 * 1024,  # 256Mb
-                    loop=loop,
-                    close_timeout=5,
-                    # todo check if speed is affected
-                    # note: seems to work w/ compression
-                    compression=None,
-                )
+        return cls(
+            await connect(
+                uri=uri,
+                ping_interval=None,  # chrome doesn't respond to pings
+                max_size=256 * 1024 * 1024,  # 256Mb
+                loop=loop,
+                close_timeout=5,
+                # todo check if speed is affected
+                # note: seems to work w/ compression
+                compression=None,
             )
-            yield instance
-        except Exception as e:
-            # todo: is this the correct context which we should be raising the error in?
-            # todo: provide more details to instance.close()
-            raise e
-        finally:
-            try:
-                await instance.close()
-            except NameError:
-                pass
+        )
 
     async def send(self, message: Union[Data, Iterable[Data], AsyncIterable[Data]]) -> None:
         await self.ws.send(message)


### PR DESCRIPTION
The old contextlib implementation was kinda ugly TBH. This will also fix issues with `WebscoketTransport.create` when used in `BaseBrowserLauncher` and `BrowserRunner`. A new function, `async_closing` is defined in `helpers.py`, and all context manager related code has been removed from `websocket_transport.py` for simplicity.

Another solution (which I'm starting more and more to think would be better) would be to ditch the context manager style used in `_recv_loop` and wrap in a good ol `try`/`except`/`finally`. This would allow us to set a reason (eg text of exception) for closing the websocket connection (otherwise, we get the default 'target closed connection [or whatever it is]), at least I think this would have some info on that. This has been implemented in #67 for reference.

@Granitosaurus 