### PR TITLE
Improve WebsocketTransport.create (option 2)

### DIFF
--- a/pyppeteer/websocket_transport.py
+++ b/pyppeteer/websocket_transport.py
@@ -3,11 +3,6 @@ from typing import Iterable, Union, AsyncIterable, Callable, Any, Optional
 
 from websockets import connect, WebSocketClientProtocol, Data
 
-try:
-    from contextlib import asynccontextmanager
-except ImportError:
-    from async_generator import asynccontextmanager
-
 
 class WebsocketTransport:
     def __init__(self, ws: WebSocketClientProtocol):
@@ -15,38 +10,19 @@ class WebsocketTransport:
         self.onclose: Optional[Callable[[], Any]] = None
         self.ws = ws
 
-    def __aenter__(self):
-        return self
-
-    def __aexit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-
-    @classmethod
-    @asynccontextmanager
     async def create(cls, uri: str, loop: asyncio.AbstractEventLoop = None) -> 'WebsocketTransport':
-        try:
-            instance = cls(
-                await connect(
-                    uri=uri,
-                    ping_interval=None,  # chrome doesn't respond to pings
-                    max_size=256 * 1024 * 1024,  # 256Mb
-                    loop=loop,
-                    close_timeout=5,
-                    # todo check if speed is affected
-                    # note: seems to work w/ compression
-                    compression=None,
-                )
+        return cls(
+            await connect(
+                uri=uri,
+                ping_interval=None,  # chrome doesn't respond to pings
+                max_size=256 * 1024 * 1024,  # 256Mb
+                loop=loop,
+                close_timeout=5,
+                # todo check if speed is affected
+                # note: seems to work w/ compression
+                compression=None,
             )
-            yield instance
-        except Exception as e:
-            # todo: is this the correct context which we should be raising the error in?
-            # todo: provide more details to instance.close()
-            raise e
-        finally:
-            try:
-                await instance.close()
-            except NameError:
-                pass
+        )
 
     async def send(self, message: Union[Data, Iterable[Data], AsyncIterable[Data]]) -> None:
         await self.ws.send(message)


### PR DESCRIPTION
This implements the other option mentioned in #65 WRT removing confusing context manager usage. Exclusive to #65.

One thing to note in this PR is that, unlike the old implementation (think pre-pup2.1.1), the connection isn't closed upon an exception, instead, the exception is passed in the arg of Connection.dispose which feeds into WebsocketTransport.close. This was done because Connection.dispose closes the connection anyway.