### PR TITLE
Remove urllib3.disable_warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ pyppeteer2
 [![PyPI](https://img.shields.io/pypi/v/pyppeteer2.svg)](https://pypi.python.org/pypi/pyppeteer2)
 [![PyPI version](https://img.shields.io/pypi/pyversions/pyppeteer2.svg)](https://pypi.python.org/pypi/pyppeteer2)
 [![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://pyppeteer.github.io/pyppeteer2/)
-[![Travis status](https://travis-ci.com/pyppeteer/pyppeteer2.svg)](https://travis-ci.com/pyppeteer/pyppeteer2)
+[![CircleCI](https://circleci.com/gh/pyppeteer/pyppeteer2.svg?style=shield)](https://circleci.com/gh/circleci/circleci-docs)
 [![codecov](https://codecov.io/gh/pyppeteer/pyppeteer2/branch/dev/graph/badge.svg)](https://codecov.io/gh/pyppeteer/pyppeteer2)
 
-_Note: this is a WIP continuation of the pyppeteer project_
+_Note: this is a continuation of the original, apparently abandoned [pyppeteer project](https://github.com/miyakogi/pyppeteer)_
 
 Unofficial Python port of [puppeteer](https://github.com/GoogleChrome/puppeteer) JavaScript (headless) chrome/chromium browser automation library.
 

--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -11,6 +11,7 @@ import stat
 import sys
 from zipfile import ZipFile
 
+import certifi
 import urllib3
 from tqdm import tqdm
 
@@ -33,7 +34,7 @@ if NO_PROGRESS_BAR.lower() in ('1', 'true'):
 
 # Windows archive name changed at r591479.
 windowsArchive = 'chrome-win' if int(REVISION) > 591479 else 'chrome-win32'
-    
+
 downloadURLs = {
     'linux': f'{BASE_URL}/Linux_x64/{REVISION}/chrome-linux.zip',
     'mac': f'{BASE_URL}/Mac/{REVISION}/chrome-mac.zip',
@@ -75,11 +76,9 @@ def download_zip(url: str) -> BytesIO:
     logger.warning('start chromium download.\n'
                    'Download may take a few minutes.')
 
-    # disable warnings so that we don't need a cert.
-    # see https://urllib3.readthedocs.io/en/latest/advanced-usage.html for more
-    urllib3.disable_warnings()
-
-    with urllib3.PoolManager() as http:
+    with urllib3.PoolManager(
+        cert_reqs="CERT_REQUIRED", ca_certs=certifi.where()
+    ) as http:
         # Get data from url.
         # set preload_content=False means using stream later.
         data = http.request('GET', url, preload_content=False)


### PR DESCRIPTION
Remove `urllib3.disable_warnings` and use `ca_certs` provided by `certifi` because using an insecure connection is a bad idea in terms of security.

- Ref. https://github.com/miyakogi/pyppeteer/issues/258#issuecomment-563075764