### PR TITLE
Use certifi along with urllib3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -94,7 +94,7 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
@@ -914,7 +914,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "54ee251dc83728c2bb78e9cbf8cc87b6a1dc827716eceba1a46afecc08cc7146"
+content-hash = "d7f2a4b4a3749380ff442b3282fb12ca77a4e97e68ac50b1ebb101fbcd2c295c"
 python-versions = "^3.6.1"
 
 [metadata.files]

--- a/pyppeteer/browser_fetcher.py
+++ b/pyppeteer/browser_fetcher.py
@@ -23,6 +23,7 @@ from typing import Union, List, Optional, Tuple, cast, Sequence, Any
 from urllib import request
 from zipfile import ZipFile
 
+import certifi
 import urllib3
 from tqdm import tqdm
 
@@ -178,7 +179,9 @@ class BrowserFetcher:
 
     def can_download(self, revision: str) -> bool:
         url = download_url(self._platform, self.downloadHost, revision)
-        http = urllib3.PoolManager()
+        http = urllib3.PoolManager(
+            cert_reqs='CERT_REQUIRED', ca_certs=certifi.where()
+        )
 
         try:
             res = http.request('HEAD', url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ urllib3 = "^1.25.8"
 aenum = "^2.2.3"
 typing_extensions = { version ="^3.7.4", python = '<3.8'}
 typing_inspect = { version ="^0.5.0", python = '<3.8'}
+certifi = "^2019.11.28"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.14.3"

--- a/tests/test_browser_fetcher.py
+++ b/tests/test_browser_fetcher.py
@@ -1,0 +1,7 @@
+from pyppeteer.browser_fetcher import BrowserFetcher
+
+
+def test_can_download():
+    fetcher = BrowserFetcher()
+    assert fetcher.can_download("588429")
+    assert not fetcher.can_download("-1")


### PR DESCRIPTION
Use `certifi` along with `urllib3`. (Ref. #75)