### PR TITLE
Update network manager with fetch endpoint

### DIFF
--- a/pyppeteer/browser.py
+++ b/pyppeteer/browser.py
@@ -8,7 +8,7 @@ from subprocess import Popen
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 
 from pyppeteer.connection import Connection
 from pyppeteer.errors import BrowserError
@@ -18,7 +18,7 @@ from pyppeteer.target import Target
 logger = logging.getLogger(__name__)
 
 
-class Browser(EventEmitter):
+class Browser(BaseEventEmitter):
     """Browser class.
 
     A Browser object is created when pyppeteer connects to chrome, either
@@ -269,7 +269,7 @@ class Browser(EventEmitter):
         return self._connection.send('Browser.getVersion')
 
 
-class BrowserContext(EventEmitter):
+class BrowserContext(BaseEventEmitter):
     """BrowserContext provides multiple independent browser sessions.
 
     When a browser is launched, it has a single BrowserContext used by default.

--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -8,7 +8,7 @@ import json
 import logging
 from typing import Awaitable, Callable, Dict, Union, TYPE_CHECKING
 
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 import websockets
 
 from pyppeteer.errors import NetworkError
@@ -21,7 +21,7 @@ logger_connection = logging.getLogger(__name__ + '.Connection')
 logger_session = logging.getLogger(__name__ + '.CDPSession')
 
 
-class Connection(EventEmitter):
+class Connection(BaseException):
     """Connection management class."""
 
     def __init__(self, url: str, loop: asyncio.AbstractEventLoop,
@@ -181,7 +181,7 @@ class Connection(EventEmitter):
         return session
 
 
-class CDPSession(EventEmitter):
+class CDPSession(BaseEventEmitter):
     """Chrome Devtools Protocol Session.
 
     The :class:`CDPSession` instances are used to talk raw Chrome Devtools

--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -21,7 +21,7 @@ logger_connection = logging.getLogger(__name__ + '.Connection')
 logger_session = logging.getLogger(__name__ + '.CDPSession')
 
 
-class Connection(BaseException):
+class Connection(BaseEventEmitter):
     """Connection management class."""
 
     def __init__(self, url: str, loop: asyncio.AbstractEventLoop,

--- a/pyppeteer/frame_manager.py
+++ b/pyppeteer/frame_manager.py
@@ -9,7 +9,7 @@ import logging
 from types import SimpleNamespace
 from typing import Any, Awaitable, Dict, Generator, List, Optional, Set, Union
 
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 
 from pyppeteer import helper
 from pyppeteer.connection import CDPSession
@@ -22,7 +22,7 @@ from pyppeteer.util import merge_dict
 logger = logging.getLogger(__name__)
 
 
-class FrameManager(EventEmitter):
+class FrameManager(BaseEventEmitter):
     """FrameManager class."""
 
     Events = SimpleNamespace(

--- a/pyppeteer/helper.py
+++ b/pyppeteer/helper.py
@@ -9,7 +9,7 @@ import logging
 import math
 from typing import Any, Awaitable, Callable, Dict, List
 
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 
 import pyppeteer
 from pyppeteer.connection import CDPSession
@@ -54,7 +54,7 @@ def getExceptionMessage(exceptionDetails: dict) -> str:
     return message
 
 
-def addEventListener(emitter: EventEmitter, eventName: str, handler: Callable
+def addEventListener(emitter: BaseEventEmitter, eventName: str, handler: Callable
                      ) -> Dict[str, Any]:
     """Add handler to the emitter and return emitter/handler."""
     emitter.on(eventName, handler)
@@ -119,7 +119,7 @@ def releaseObject(client: CDPSession, remoteObject: dict
     return fut_none
 
 
-def waitForEvent(emitter: EventEmitter, eventName: str,  # noqa: C901
+def waitForEvent(emitter: BaseEventEmitter, eventName: str,  # noqa: C901
                  predicate: Callable[[Any], bool], timeout: float,
                  loop: asyncio.AbstractEventLoop) -> Awaitable:
     """Wait for an event emitted from the emitter."""

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -147,7 +147,7 @@ class NetworkManager(BaseEventEmitter):
 
     async def _onRequestPaused(self, event):
         if not self._userRequestInterceptionEnabled and self._protocolRequestInterceptionEnabled:
-          await self._client.send('Fetch.continueRequest', {'requestId': event.get('requestId')})
+            await self._client.send('Fetch.continueRequest', {'requestId': event.get('requestId')})
 
         requestHash = generateRequestHash(event['request'])
         requestId = self._requestHashToRequestIds.firstValue(requestHash)

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -474,11 +474,11 @@ class Request(object):
 
         ``response`` is a dictionary which can have the following fields:
 
-        * ``status`` (int): Response status code, defaults to 200.
-        * ``headers`` (dict): Optional response headers.
-        * ``contentType`` (str): If set, equals to setting ``Content-Type``
-          response header.
+        * ``responseCode`` (int): Response status code, defaults to 200.
+        * ``responseHeaders`` (dict): Optional response headers.
         * ``body`` (str|bytes): Optional response body.
+        * ``responsePhrase`` (string): A textual representation of responseCode.
+        If absent, a standard phrase matching responseCode is used.
         """
         if self._url.startswith('data:'):
             return
@@ -517,9 +517,12 @@ class Request(object):
 
         rawResponse = base64.b64encode(responseBuffer).decode('ascii')
         try:
-            await self._client.send('Network.continueInterceptedRequest', {
-                'interceptionId': self._interceptionId,
-                'rawResponse': rawResponse,
+            await self._client.send('Fetch.fulfillRequest', {
+                'requestId': self._interceptionId,
+                'responseCode':  statusCode if statusCode is not None else 200,
+                'responsePhrase': statusTexts[statusText] if statusText is not None else statusText[200],
+                'responseHeaders': responseHeaders,
+                'body': rawResponse
             })
         except Exception as e:
             debugError(logger, e)

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -596,8 +596,8 @@ class Request(object):
             raise NetworkError('Request is already handled.')
         self._interceptionHandled = True
         try:
-            await self._client.send('Network.continueInterceptedRequest', dict(
-                interceptionId=self._interceptionId,
+            await self._client.send('Fetch.failRequest', dict(
+                requestId=self._interceptionId,
                 errorReason=errorReason,
             ))
         except Exception as e:

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -55,13 +55,14 @@ class NetworkManager(BaseEventEmitter):
         self._requestHashToInterceptionIds = Multimap()
         self._requestIdToRequestWillBeSentEvent = Multimap()
 
-        self._client.on('Fetch.requestPaused', self._onRequestPaused)
-        self._client.on('Fetch.authRequired', self._onAuthRequired)
-        self._client.on(
-            'Network.requestWillBeSent',
-            lambda event: self._client._loop.create_task(
-                self._onRequestWillBeSent(event)
-            ),
+        self._client.on('Fetch.requestPaused',
+                        lambda event: self._client._loop.create_task(self._onRequestPaused(event))
+        )
+        self._client.on('Fetch.requestPaused',
+                        lambda event: self._client._loop.create_task(self._onAuthRequired(event))
+        )
+        self._client.on('Network.requestWillBeSent',
+                        lambda event: self._client._loop.create_task(self._onRequestWillBeSent(event))
         )
         self._client.on('Network.requestServedFromCache', self._onRequestServedFromCache)  # noqa: #501
         self._client.on('Network.responseReceived', self._onResponseReceived)

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -476,10 +476,19 @@ class Request(object):
             raise NetworkError('Request is already handled.')
 
         self._interceptionHandled = True
-        opt = {'interceptionId': self._interceptionId}
-        opt.update(overrides)
+        url = overrides.get('url')
+        method = overrides.get('method')
+        postData = overrides.get('postData')
+        headers = overrides.get('headers')
         try:
-            await self._client.send('Fetch.continueRequest', opt)
+            await self._client.send('Fetch.continueRequest',
+                                    {'requestId': self._interceptionId,
+                                     'url': url,
+                                     'method': method,
+                                     'postData': postData,
+                                     'headers': headersArray(headers) if headers else None
+                                     }
+                                    )
         except Exception as e:
             debugError(logger, e)
 

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -795,7 +795,9 @@ class SecurityDetails(object):
 
 
 def headersArray(headers: dict) -> List[Dict[str, str]]:
-    """Convert headers to array."""
+    """Convert headers dict to array.
+    Returns the array of JSON objects with structure [{'name: headers_key, 'value': headers}, ]
+    """
     result = []
     for name in headers:
         result.append({'name': name, 'value': f"{headers[name]} "})

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -120,16 +120,26 @@ class NetworkManager(BaseEventEmitter):
             return
         self._protocolRequestInterceptionEnabled = enabled
         patterns = [{'urlPattern': '*'}] if enabled else []
-        await asyncio.gather(
-            self._client.send(
-                'Network.setCacheDisabled',
-                {'cacheDisabled': enabled},
-            ),
-            self._client.send(
-                'Fetch.enable',
-                {'patterns': patterns, 'handleAuthRequests': self._handleAuthRequests},
+        if enabled:
+            await asyncio.gather(
+                self._client.send(
+                    'Network.setCacheDisabled',
+                    {'cacheDisabled': enabled},
+                ),
+                self._client.send(
+                    'Fetch.enable',
+                    {'patterns': patterns, 'handleAuthRequests': self._handleAuthRequests},
+                )
             )
-        )
+        else:
+            await asyncio.gather(
+                self._client.send(
+                    'Network.setCacheDisabled',
+                    {'cacheDisabled': False},
+                ),
+                self._client.send('Fetch.disable')
+            )
+
 
     async def _onRequestPaused(self, event):
         if not self._userRequestInterceptionEnabled and self._protocolRequestInterceptionEnabled:

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from typing import Awaitable, Dict, List, Optional, Union, TYPE_CHECKING
 from urllib.parse import unquote
 
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 
 from pyppeteer.connection import CDPSession
 from pyppeteer.errors import NetworkError
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class NetworkManager(EventEmitter):
+class NetworkManager(BaseEventEmitter):
     """NetworkManager class."""
 
     Events = SimpleNamespace(

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -1796,15 +1796,3 @@ class ConsoleMessage(object):
     def args(self) -> List[JSHandle]:
         """Return list of args (JSHandle) of this message."""
         return self._args
-
-
-async def craete(*args: Any, **kwargs: Any) -> Page:
-    """[Deprecated] miss-spelled function.
-
-    This function is undocumented and will be removed in future release.
-    """
-    logger.warning(
-        '`craete` function is deprecated and will be removed in future. '
-        'Use `Page.create` instead.'
-    )
-    return await Page.create(*args, **kwargs)

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 from typing import TYPE_CHECKING
 
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 
 from pyppeteer import helper
 from pyppeteer.connection import CDPSession
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Page(EventEmitter):
+class Page(BaseEventEmitter):
     """Page class.
 
     This class provides methods to interact with a single tab of chrome. One

--- a/pyppeteer/worker.py
+++ b/pyppeteer/worker.py
@@ -6,7 +6,7 @@
 import logging
 from typing import Any, Callable, Dict, List, TYPE_CHECKING
 
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 
 from pyppeteer.execution_context import ExecutionContext, JSHandle
 from pyppeteer.helper import debugError
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Worker(EventEmitter):
+class Worker(BaseEventEmitter):
     """The Worker class represents a WebWorker.
 
     The events `workercreated` and `workerdestroyed` are emitted on the page


### PR DESCRIPTION
- Use `BaseEventEmitter` from `pyee 7`
- Updated NetworkManager to use `Fetch` endpoint, as `Network.setRequestInterception` has been deprecated.
https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setRequestInterception

- Updated `abort`, `continue_`, `respond` methods of Request class.

TODO:
- [ ] run tests
- [ ] delete print()