### PR TITLE
revamp test_tracing.py

### DIFF
--- a/pyppeteer/tracing.py
+++ b/pyppeteer/tracing.py
@@ -4,8 +4,9 @@
 """Tracing module."""
 
 from pathlib import Path
-from typing import Sequence
+from typing import Sequence, Union
 
+from pyppeteer import helpers
 from pyppeteer.connection import CDPSession
 
 
@@ -28,7 +29,9 @@ class Tracing:
         self._recording = False
         self._path = ''
 
-    async def start(self, path: str = '', screenshots: bool = False, categories: Sequence[str] = None) -> None:
+    async def start(
+        self, path: Union[Path, str] = '', screenshots: bool = False, categories: Sequence[str] = None
+    ) -> None:
         """Start tracing.
 
         Only one trace can be active at a time per browser.
@@ -76,17 +79,20 @@ class Tracing:
         :return: trace data as string.
         """
         contentFuture = self._client.loop.create_future()
+
+        async def complete_trace(event):
+            nonlocal self, contentFuture
+            result = await helpers.readProtocolStream(self._client, event['stream'], self._path)
+            contentFuture.set_result(result)
+
         self._client.once(
-            'Tracing.tracingComplete',
-            lambda event: self._client.loop.create_task(
-                self._readStream(event.get('stream'), self._path)
-            ).add_done_callback(lambda fut: contentFuture.set_result(fut.result())),
+            'Tracing.tracingComplete', complete_trace,
         )
         await self._client.send('Tracing.end')
         self._recording = False
         return await contentFuture
 
-    async def _readStream(self, handle: str, path: str) -> str:
+    async def _readStream(self, handle: str, path: Union[Path, str]) -> str:
         # might be better to return as bytes
         eof = False
         bufs = []
@@ -98,7 +104,5 @@ class Tracing:
 
         result = ''.join(bufs)
         if path:
-            file = Path(path)
-            with file.open('w') as f:
-                f.write(result)
+            Path(path).write_text(result)
         return result

--- a/pyppeteer/tracing.py
+++ b/pyppeteer/tracing.py
@@ -91,18 +91,3 @@ class Tracing:
         await self._client.send('Tracing.end')
         self._recording = False
         return await contentFuture
-
-    async def _readStream(self, handle: str, path: Union[Path, str]) -> str:
-        # might be better to return as bytes
-        eof = False
-        bufs = []
-        while not eof:
-            response = await self._client.send('IO.read', {'handle': handle})
-            eof = response.get('eof', False)
-            bufs.append(response.get('data', ''))
-        await self._client.send('IO.close', {'handle': handle})
-
-        result = ''.join(bufs)
-        if path:
-            Path(path).write_text(result)
-        return result

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -2,72 +2,74 @@
 # -*- coding: utf-8 -*-
 
 import json
-import unittest
+import time
 from pathlib import Path
 
+import pytest
 from pyppeteer.errors import NetworkError
 from syncer import sync
 
 
-class TestTracing:
-    def setUp(self):
-        self.outfile = Path(__file__).parent / 'trace.json'
-        if self.outfile.is_file():
-            self.outfile.unlink()
-        super().setUp()
+@pytest.fixture
+def temp_file_path(tmpdir):
+    return Path(tmpdir / f'{time.perf_counter_ns()}file.json')
 
-    def tearDown(self):
-        if self.outfile.is_file():
-            self.outfile.unlink()
-        super().tearDown()
 
-    @sync
-    async def test_tracing(self):
-        await self.page.tracing.start({'path': str(self.outfile)})
-        await self.page.goto(self.url)
-        await self.page.tracing.stop()
-        self.assertTrue(self.outfile.is_file())
+@sync
+async def test_tracing(isolated_page, temp_file_path, server):
+    await isolated_page.tracing.start(path=temp_file_path)
+    await isolated_page.goto(server / 'grid.html')
+    await isolated_page.tracing.stop()
+    assert temp_file_path.is_file() and temp_file_path.stat().st_size > 0
 
-    @sync
-    async def test_custom_categories(self):
-        await self.page.tracing.start(
-            {'path': str(self.outfile), 'categories': ['disabled-by-default-v8.cpu_profiler.hires'],}
-        )
-        await self.page.tracing.stop()
-        self.assertTrue(self.outfile.is_file())
-        with self.outfile.open() as f:
-            trace_json = json.load(f)
-        self.assertIn(
-            'disabled-by-default-v8.cpu_profiler.hires', trace_json['metadata']['trace-config'],
-        )
 
-    @sync
-    async def test_tracing_two_page_error(self):
-        await self.page.tracing.start({'path': str(self.outfile)})
-        new_page = await self.browser.newPage()
-        with self.assertRaises(NetworkError):
-            await new_page.tracing.start({'path': str(self.outfile)})
+@sync
+async def test_custom_categories(isolated_page, temp_file_path):
+    await isolated_page.tracing.start(path=temp_file_path, categories=['disabled-by-default-v8.cpu_profiler.hires'])
+    await isolated_page.tracing.stop()
+    assert temp_file_path.is_file() and temp_file_path.stat().st_size > 0
+    trace_json = json.loads(temp_file_path.read_text())
+    assert 'disabled-by-default-v8.cpu_profiler.hires' in trace_json['metadata']['trace-config']
+
+
+@sync
+async def test_two_page_error(isolated_page, shared_browser, temp_file_path):
+    await isolated_page.tracing.start(path=temp_file_path)
+    try:
+        new_page = await shared_browser.newPage()
+        with pytest.raises(NetworkError):
+            await new_page.tracing.start(path=temp_file_path)
+    finally:
         await new_page.close()
-        await self.page.tracing.stop()
+    await isolated_page.tracing.stop()
 
-    @sync
-    async def test_return_buffer(self):
-        await self.page.tracing.start(screenshots=True, path=str(self.outfile))
-        await self.page.goto(self.url + 'assets/grid.html')
-        trace = await self.page.tracing.stop()
-        with self.outfile.open('r') as f:
-            buf = f.read()
-        self.assertEqual(trace, buf)
 
-    @unittest.skip('Not implemented')
-    @sync
-    async def test_return_null_on_error(self):
-        await self.page.tracing.start(screenshots=True)
-        await self.page.goto(self.url + 'assets/grid.html')
+@sync
+async def test_return_buffer(isolated_page, server, temp_file_path):
+    await isolated_page.tracing.start(screenshots=True, path=temp_file_path)
+    await isolated_page.goto(server / 'grid.html')
+    trace = await isolated_page.tracing.stop()
+    assert trace == temp_file_path.read_text()
 
-    @sync
-    async def test_without_path(self):
-        await self.page.tracing.start(screenshots=True)
-        await self.page.goto(self.url + 'assets/grid.html')
-        trace = await self.page.tracing.stop()
-        self.assertIn('screenshot', trace)
+
+@sync
+async def test_works_without_any_options(isolated_page, server):
+    await isolated_page.tracing.start()
+    await isolated_page.goto(server / 'grid.html')
+    trace = await isolated_page.tracing.stop()
+    assert trace
+
+
+@sync
+@pytest.mark.skip(reason='No analogous python behaviour known')
+async def test_return_null_on_error(isolated_page, server):
+    await isolated_page.tracing.start(screenshots=True)
+    await isolated_page.goto(server / 'grid.html')
+
+
+@sync
+async def test_without_path(isolated_page, server):
+    await isolated_page.tracing.start(screenshots=True)
+    await isolated_page.goto(server / 'grid.html')
+    trace = await isolated_page.tracing.stop()
+    assert 'screenshot' in trace


### PR DESCRIPTION
Nothing too fancy, just a pytest refactoring of the tests that were already present.

Fixed:
 - typings of tracing.stop function, now (correctly) allows for Path object
 - factored out `_readStream` into `helpers.py`, mirror of the puppeteer source
   - cleaned up implementation so it look more like python and less like JS callbacks
     - sidenote: this was in part made possible due to the fact that we're using `AsyncIOEventEmitter` now 😃 
 - corrected comment that was physically close to the code I was working on, but unrelated 😉 
