### PR TITLE
Fix error in test_abnormal_crash.py. Use sys.platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tmp.js
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/tests/test_abnormal_crash.py
+++ b/tests/test_abnormal_crash.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import unittest
+import sys
 
 import pytest
 from syncer import sync
@@ -22,7 +23,7 @@ class TestBrowserCrash(unittest.TestCase):
         browser.process.terminate()
         browser.process.wait()
 
-        if current_platform().startswith('win'):
+        if sys.platform.startswith('win'):
             # wait for terminating browser process
             await asyncio.sleep(1)
 


### PR DESCRIPTION
## Overview
When running  tests with pytest tests the test for test_abnormal_crash.py fails. Upon closer inspection,
VSCode reports that current_platform() is not defined. Manual inspection confirms this.

sys.platform can be used as a drop-in replacement for this. As sys is a first party python module an extra import seemed justifiable 

## Checklist
- [x] - Fix error in test_abnormal_crash.py. Use sys.platform
- [x] - Test is successful 

## Platform 
- Windows 10

Let me know if you require additional information and I hope this is found to be useful 

Edit: I forgot to add that I added tmp.js to the .gitignore 