### PR TITLE
Make emulate method original puppeteer alike.

### DIFF
--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -993,8 +993,7 @@ class Page(AsyncIOEventEmitter):
 
         * ``userAgent`` (str): user agent string.
         """
-        await self.setViewport(viewport)
-        await self.setUserAgent(userAgent)
+        await asyncio.gather(self.setViewport(viewport), self.setUserAgent(userAgent))
 
     async def setJavaScriptEnabled(self, enabled: bool) -> None:
         """Set JavaScript enable/disable."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,4 @@ multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
-known_third_party = ["appdirs", "certifi", "livereload", "networkx", "pyee", "pyppeteer", "pytest", "syncer", "tests", "tornado", "tqdm", "urllib3", "websockets"]
+known_third_party = ["appdirs", "certifi", "livereload", "networkx", "orderedset", "pyee", "pyppeteer", "pytest", "syncer", "tests", "tornado", "tqdm", "urllib3", "websockets"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,4 @@ multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
-known_third_party = ["appdirs", "certifi", "livereload", "networkx", "orderedset", "pyee", "pyppeteer", "pytest", "syncer", "tests", "tornado", "tqdm", "urllib3", "websockets"]
+known_third_party = ["appdirs", "certifi", "livereload", "networkx", "pyee", "pyppeteer", "pytest", "syncer", "tests", "tornado", "tqdm", "urllib3", "websockets"]


### PR DESCRIPTION
Original puppeteer uses `Promise.all()`
```
async emulate(options) {
    await Promise.all([
      this.setViewport(options.viewport),
      this.setUserAgent(options.userAgent),
    ]);
  }
```

I believe `asyncio.gather()`  is more correct representation of this