### PR TITLE
bug fix: when remote_debugging_port is set

### DIFF
--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -104,8 +104,14 @@ class Launcher(object):
 
         self.temporaryUserDataDir: Optional[str] = None
 
-        if not any(arg for arg in self.chromeArguments if arg.startswith('--remote-debugging-')):
+        remote_debugging_args = [arg for arg in self.chromeArguments
+                                 if arg.startswith('--remote-debugging-')]
+        if not any(remote_debugging_args):
             self.chromeArguments.append(f'--remote-debugging-port={self.port}')
+        else:
+            # Replace the auto-generated port with the provided one
+            self.port = remote_debugging_args[0].split("=")[1]
+            self.url = f'http://127.0.0.1:{self.port}'
 
         if not any(arg for arg in self.chromeArguments if arg.startswith('--user-data-dir')):
             if not CHROME_PROFILE_PATH.exists():


### PR DESCRIPTION
When remote_debugging_port is set, launcher fails since url is created with the auto-generated port which mismatches the provided one. Now, provided port replaces the auto-generated one in the url.