### PR TITLE
#154 Update launcher options to avoid OS.Error

### DIFF
--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -78,7 +78,8 @@ class Launcher(object):
 
         ignoreDefaultArgs = options.get('ignoreDefaultArgs', False)
         args: List[str] = options.get('args', list())
-        self.dumpio = options.get('dumpio', False)
+        #default to True to avoid OS open file errors
+        self.dumpio = options.get('dumpio', True)
         executablePath = options.get('executablePath')
         self.env = options.get('env')
         self.handleSIGINT = options.get('handleSIGINT', True)
@@ -140,7 +141,8 @@ class Launcher(object):
         options = dict()
         options['env'] = self.env
         if not self.dumpio:
-            options['stdout'] = subprocess.PIPE
+            #changed from PIPE to DEVNULL since we never read the pipe
+            options['stdout'] = subprocess.DEVNULL
             options['stderr'] = subprocess.STDOUT
 
         self.proc = subprocess.Popen(  # type: ignore

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -79,7 +79,7 @@ class Launcher(object):
         ignoreDefaultArgs = options.get('ignoreDefaultArgs', False)
         args: List[str] = options.get('args', list())
         #default to True to avoid OS open file errors
-        self.dumpio = options.get('dumpio', True)
+        self.dumpio = options.get('dumpio', False)
         executablePath = options.get('executablePath')
         self.env = options.get('env')
         self.handleSIGINT = options.get('handleSIGINT', True)

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -78,7 +78,6 @@ class Launcher(object):
 
         ignoreDefaultArgs = options.get('ignoreDefaultArgs', False)
         args: List[str] = options.get('args', list())
-        #default to True to avoid OS open file errors
         self.dumpio = options.get('dumpio', False)
         executablePath = options.get('executablePath')
         self.env = options.get('env')
@@ -141,7 +140,7 @@ class Launcher(object):
         options = dict()
         options['env'] = self.env
         if not self.dumpio:
-            #changed from PIPE to DEVNULL since we never read the pipe
+            # discard stdout, it's never read in any case.
             options['stdout'] = subprocess.DEVNULL
             options['stderr'] = subprocess.STDOUT
 


### PR DESCRIPTION
Implemented and tested fix idea in #154 

Sure we can pass dumpio=True in the launcher options, but the DEVNULL change solves this error with the default behavior as well. I'm changing dumpio=True by default just to be safe. 