### PR TITLE
Fix hard-coded timeout for get_ws_endpoint

### DIFF
--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -88,7 +88,7 @@ class Launcher(object):
         self.defaultViewport = options.get('defaultViewport', {'width': 800, 'height': 600})  # noqa: E501
         self.slowMo = options.get('slowMo', 0)
         self.timeout = options.get('timeout', 30000)
-        self.wsEndpointTimeout = options.get('ws_endpoint_timeout', 30000)
+        self.wsEndpointTimeout = options.get('wsEndpointTimeout', 30000)
         self.autoClose = options.get('autoClose', True)
 
         logLevel = options.get('logLevel')


### PR DESCRIPTION
I've faced with an error 
![image](https://user-images.githubusercontent.com/40602607/96377360-fa293e80-118d-11eb-8238-ad55a74a5870.png). 

Seems like we need these new options to make it configurable. This a common error for small instances in the cloud.