### PR TITLE
fix: version in 0.2.3 to remove the rc in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyppeteer"
-version = "0.2.3.rc2"
+version = "0.2.3"
 description = "Headless chrome/chromium automation library (unofficial port of puppeteer)"
 readme = 'README.md'
 license = "MIT"


### PR DESCRIPTION
Version 0.2.3 is still showing `0.2.3.rc2` as it's version number.

Sorry, it looks like I can't make a pull request against a tag.