### PR TITLE
ensure that versions match between release name and__version__

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@ History
 
 * [populate me]
 
+## Version 0.2.5
+
+* Match package version and \_\_version__ (🤦‍♂️)
+* Use `importlib_metadata` so this isn't a problem in the future
+
 ## Version 0.2.4
 
 * Update `pyee` dependency breaking build failures on NixOS + Fedora packaging systems (#207)

--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -19,6 +19,8 @@ try:
 except Exception:
     pass
 
+from appdirs import AppDirs
+
 __chromium_revision__ = '588429'
 __base_puppeteer_version__ = 'v1.6.0'
 __pyppeteer_home__ = os.environ.get(

--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -6,11 +6,19 @@
 import logging
 import os
 
-from appdirs import AppDirs
+try:
+    # noinspection PyCompatibility
+    from importlib.metadata import version
+except ModuleNotFoundError:
+    # noinspection PyUnresolvedReferences
+    # <3.8 backport
+    from importlib_metadata import version
 
-__author__ = """Hiroyuki Takagi"""
-__email__ = 'miyako.dev@gmail.com'
-__version__ = '0.2.4'
+try:
+    __version__ = version('wheel')
+except Exception:
+    pass
+
 __chromium_revision__ = '588429'
 __base_puppeteer_version__ = 'v1.6.0'
 __pyppeteer_home__ = os.environ.get(

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -228,7 +228,7 @@ def get_ws_endpoint(url) -> str:
             with urlopen(url) as f:
                 data = json.loads(f.read().decode())
             break
-        except URLError as e:
+        except URLError:
             continue
         time.sleep(0.1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyppeteer"
-version = "0.2.4"
+version = "0.2.5"
 description = "Headless chrome/chromium automation library (unofficial port of puppeteer)"
 readme = 'README.md'
 license = "MIT"
@@ -51,9 +51,11 @@ appdirs = "^1.4.3"
 tqdm = "^4.42.1"
 pyee = "^8.1.0"
 urllib3 = "^1.25.8"
+# todo: update this dep when tox releases patch version w/ https://github.com/tox-dev/tox/pull/1764
+importlib-metadata = { version = "^2.1.1", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
-tox = "^3.14.3"
+tox = "^3.20.1"
 syncer = "^1.3.0"
 livereload = "^2.6.1"
 flake8 = "^3.7.9"


### PR DESCRIPTION
This has happened to me, this has happened to @Granitosaurus, and with this PR we should never have this happen again :). Also removed some out of date/superfluous dunder metadata. 

Also started fixing linter issues, then noticed tox envs were messed up, then quit while I was ahead. One day we'll merge pup2.1.1 :)