### PR TITLE
Do not try to set an exception on finished futures

### DIFF
--- a/pyppeteer/connection/__init__.py
+++ b/pyppeteer/connection/__init__.py
@@ -178,12 +178,13 @@ class Connection(AsyncIOEventEmitter):
         self._transport.onclose = None
 
         for cb in self._callbacks.values():
-            cb.set_exception(
-                rewriteError(
-                    cb.error,  # type: ignore
-                    f'Protocol error {cb.method}: Target closed.',  # type: ignore
+            if not cb.done():
+                cb.set_exception(
+                    rewriteError(
+                        cb.error,  # type: ignore
+                        f'Protocol error {cb.method}: Target closed.',  # type: ignore
+                    )
                 )
-            )
         self._callbacks.clear()
 
         for session in self._sessions.values():

--- a/pyppeteer/connection/cdpsession.py
+++ b/pyppeteer/connection/cdpsession.py
@@ -90,12 +90,13 @@ class CDPSession(AsyncIOEventEmitter):
 
     def _onClosed(self) -> None:
         for cb in self._callbacks.values():
-            cb.set_exception(
-                rewriteError(
-                    cb.error,  # type: ignore
-                    f'Protocol error {cb.method}: Target closed.',  # type: ignore
+            if not cb.done():
+                cb.set_exception(
+                    rewriteError(
+                        cb.error,  # type: ignore
+                        f'Protocol error {cb.method}: Target closed.',  # type: ignore
+                    )
                 )
-            )
         self._callbacks.clear()
         self._connection = None
         self.emit(Events.CDPSession.Disconnected)


### PR DESCRIPTION
This fixes any InvalidState exceptions that occurred when terminating
with an unrelated error.