### PR TITLE
Fix tqdm exception when NO_PROGRESS_BAR is True

### DIFF
--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -89,17 +89,17 @@ def download_zip(url: str) -> BytesIO:
         except (KeyError, ValueError, AttributeError):
             total_length = 0
 
-        process_bar = tqdm(
-            total=total_length,
-            file=os.devnull if NO_PROGRESS_BAR else None,
-        )
-
         # 10 * 1024
         _data = BytesIO()
-        for chunk in data.stream(10240):
-            _data.write(chunk)
-            process_bar.update(len(chunk))
-        process_bar.close()
+        if NO_PROGRESS_BAR:
+            for chunk in data.stream(10240):
+                _data.write(chunk)
+        else:
+            process_bar = tqdm(total=total_length)
+            for chunk in data.stream(10240):
+                _data.write(chunk)
+                process_bar.update(len(chunk))
+            process_bar.close()
 
     logger.warning('\nchromium download done.')
     return _data


### PR DESCRIPTION
With `tqdm` version 4.56.2 (Released: Feb 11, 2021) installed, if `NO_PROGRESS_BAR` is set to `True` and Chromium needs to be installed `pyppeteer` will crash with the following exception :

```
[W:pyppeteer.chromium_downloader] start chromium download.
Download may take a few minutes.
Traceback (most recent call last):
  File "/usr/local/bin/pge.py", line 129, in <module>
    usage, weather = asyncio.get_event_loop().run_until_complete(get_pge_data())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/usr/local/bin/pge.py", line 64, in get_pge_data
    browser = await launch(args=pypargs, headless=not args.verbose)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pyppeteer/launcher.py", line 306, in launch
    return await Launcher(options, **kwargs).launch()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pyppeteer/launcher.py", line 119, in __init__
    download_chromium()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pyppeteer/chromium_downloader.py", line 146, in download_chromium
    extract_zip(download_zip(get_url()), DOWNLOADS_FOLDER / REVISION)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pyppeteer/chromium_downloader.py", line 92, in download_zip
    process_bar = tqdm(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 1098, in __init__
    self.refresh(lock_args=self.lock_args)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 1326, in refresh
    self.display()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 1474, in display
    self.sp(self.__str__() if msg is None else msg)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 348, in print_status
    fp_write('\r' + s + (' ' * max(last_len[0] - len_s, 0)))
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 341, in fp_write
    fp.write(_unicode(s))
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/utils.py", line 89, in __getattr__
    return getattr(self._wrapped, name)
AttributeError: 'str' object has no attribute 'write'
Exception ignored in: <function tqdm.__del__ at 0x7f49f20158b0>
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 1134, in __del__
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 1269, in close
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/std.py", line 1266, in fp_write
  File "/home/ubuntu/.local/lib/python3.8/site-packages/tqdm/utils.py", line 89, in __getattr__
AttributeError: 'str' object has no attribute 'write'
```

This pull request fixes this crash by avoiding invoking `tqdm` if `NO_PROGRESS_BAR` is `True`