### PR TITLE
fix encoding error

### DIFF
--- a/pyppeteer/tracing.py
+++ b/pyppeteer/tracing.py
@@ -94,6 +94,6 @@ class Tracing(object):
         result = ''.join(bufs)
         if path:
             file = Path(path)
-            with file.open('w') as f:
+            with file.open('w', encoding='utf-8') as f:
                 f.write(result)
         return result


### PR DESCRIPTION
Exception in callback Tracing.stop.<locals>.<lambda>.<locals>.<lambda>(<Task finishe...<undefined>')>) at C:\Users\edt\AppData\Local\Programs\Python\Python38\lib\site-packages\pyppeteer\tracing.py:77
handle: <Handle Tracing.stop.<locals>.<lambda>.<locals>.<lambda>(<Task finishe...<undefined>')>) at C:\Users\edt\AppData\Local\Programs\Python\Python38\lib\site-packages\pyppeteer\tracing.py:77>
Traceback (most recent call last):
  File "C:\Users\edt\AppData\Local\Programs\Python\Python38\lib\asyncio\events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "C:\Users\edt\AppData\Local\Programs\Python\Python38\lib\site-packages\pyppeteer\tracing.py", line 77, in <lambda>
    lambda fut: contentPromise.set_result(fut.result())
  File "C:\Users\edt\AppData\Local\Programs\Python\Python38\lib\site-packages\pyppeteer\tracing.py", line 98, in _readStream
    f.write(result)
  File "C:\Users\edt\AppData\Local\Programs\Python\Python38\lib\encodings\cp1251.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u0119' in position 949344: character maps to <undefined>