### PR TITLE
Chromium download fixes (file not found)

### DIFF
--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -72,36 +72,41 @@ def get_url() -> str:
 
 def download_zip(url: str) -> BytesIO:
     """Download data from url."""
-    logger.warning('start chromium download.\n'
+    logger.warning('Starting Chromium download. '
                    'Download may take a few minutes.')
 
-    # disable warnings so that we don't need a cert.
-    # see https://urllib3.readthedocs.io/en/latest/advanced-usage.html for more
-    urllib3.disable_warnings()
+    # Uncomment the statement below to disable HTTPS warnings and allow 
+    # download without certificate verification. This is *strongly* as it 
+    # opens the code to man-in-the-middle (and other) vulnerabilities; see
+    # https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
+    # for more.
+    # urllib3.disable_warnings()
 
     with urllib3.PoolManager() as http:
         # Get data from url.
         # set preload_content=False means using stream later.
-        data = http.request('GET', url, preload_content=False)
-
-        try:
-            total_length = int(data.headers['content-length'])
-        except (KeyError, ValueError, AttributeError):
-            total_length = 0
-
-        process_bar = tqdm(
-            total=total_length,
-            file=os.devnull if NO_PROGRESS_BAR else None,
-        )
+        r = http.request('GET', url, preload_content=False)
+        if r.status >= 400:
+            raise OSError(f'Chromium downloadable not found at {url}: '
+                          f'Received {r.data.decode()}.\n')
 
         # 10 * 1024
         _data = BytesIO()
-        for chunk in data.stream(10240):
-            _data.write(chunk)
-            process_bar.update(len(chunk))
-        process_bar.close()
+        if NO_PROGRESS_BAR:
+            for chunk in r.stream(10240):
+                _data.write(chunk)
+        else:
+            try:
+                total_length = int(r.headers['content-length'])
+            except (KeyError, ValueError, AttributeError):
+                total_length = 0
+            process_bar = tqdm(total=total_length)
+            for chunk in r.stream(10240):
+                _data.write(chunk)
+                process_bar.update(len(chunk))
+            process_bar.close()
 
-    logger.warning('\nchromium download done.')
+    logger.warning('\nChromium download done.')
     return _data
 
 


### PR DESCRIPTION
Currently `pyppeteer-install` gives the following error when a Chromium downloadable is not found, which is confusing since it both says `chromium download done` and `zipfile.BadZipFile: File is not a zip file`:

```
[W:pyppeteer.chromium_downloader]
chromium download done.
Traceback (most recent call last):
[...]
zipfile.BadZipFile: File is not a zip file
```

This fix checks for HTTP errors, and if an error is found will generate a clear error. Here is an example obtained by setting PYPPETEER_CHROMIUM_REVISION to 1 (there's no revision 1):
```
[W:pyppeteer.chromium_downloader] Starting Chromium download. Download may take a few minutes.
Traceback (most recent call last):
[...]
OSError: Chromium downloadable not found at https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1/chrome-win32.zip: Received <?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: chromium-browser-snapshots/Win_x64/1/chrome-win32.zip</Details></Error>.
```

This pull request also incorporates pyppeteer#224 (Fix tqdm exception when NO_PROGRESS_BAR is True).

Finally, it closes a gaping man-in-the-middle security hole and defaults the code to security-first (duh!).