### PR TITLE
support websockets 9.0

### DIFF
--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -10,10 +10,7 @@ from typing import Awaitable, Callable, Dict, Union, TYPE_CHECKING
 
 from pyee import EventEmitter
 import websockets
-try:
-    from websockets.legacy.client import connect as ws_connect
-except:  # websockets <9.0
-    from websockets.client import connect as ws_connect
+from websockets.legacy.client import connect as ws_connect
 
 from pyppeteer.errors import NetworkError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ importlib-metadata = { version = "^2.1.1", python = "<3.8" }
 pyee = "^8.1.0"
 tqdm = "^4.42.1"
 urllib3 = "^1.25.8"
-websockets = ">=8.1"
+websockets = "^9.1"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.20.1"


### PR DESCRIPTION
Implemented support for ``websocket`` 9.0 refactoring as per https://websockets.readthedocs.io/en/stable/changelog.html#id4 while still supporting websocket 8.1, to which _pyppeteer_ was pinned.

Can this be pushed to PyPi to avoid pip dependency version hell?