### PR TITLE
Class page must be an inheritance of AsyncIOEventEmitter instead base EventEmitter class to use method page.on's callback in coroutine

### DIFF
--- a/pyppeteer/browser.py
+++ b/pyppeteer/browser.py
@@ -8,7 +8,7 @@ from subprocess import Popen
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 from pyppeteer.connection import Connection
 from pyppeteer.errors import BrowserError
@@ -18,7 +18,7 @@ from pyppeteer.target import Target
 logger = logging.getLogger(__name__)
 
 
-class Browser(EventEmitter):
+class Browser(AsyncIOEventEmitter):
     """Browser class.
 
     A Browser object is created when pyppeteer connects to chrome, either
@@ -269,7 +269,7 @@ class Browser(EventEmitter):
         return self._connection.send('Browser.getVersion')
 
 
-class BrowserContext(EventEmitter):
+class BrowserContext(AsyncIOEventEmitter):
     """BrowserContext provides multiple independent browser sessions.
 
     When a browser is launched, it has a single BrowserContext used by default.

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 from typing import TYPE_CHECKING
 
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 from pyppeteer import helper
 from pyppeteer.connection import CDPSession
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Page(EventEmitter):
+class Page(AsyncIOEventEmitter):
     """Page class.
 
     This class provides methods to interact with a single tab of chrome. One


### PR DESCRIPTION
Starting with pyee ver 8.x.x default class EventEmitter lost ability to run coroutines using asyncio.ensure_future
This functionality in pyee provided by special class - AsyncIOEventEmitter (see help(pyee.AsyncIOEventEmitter))

So code that uses asyncio.ensure_future would throw error with pyee version >=8.0.0 

Latest pyppeteer (pyppeteer-0.2.5) code has dependencies pyee (>=8.1.0,<9.0.0)

How to reproduce problem:


```python
import asyncio
from pyppeteer import launch

async def response_worker(response):
    print(f'response:{response.request.url}')

async def main():
    browser = await launch()
    page = await browser.newPage()
    page.on("response", response_worker)
    await page.goto('https://example.com')
    await asyncio.sleep(3)
    await browser.close()

asyncio.run(main())
```

pyee <8.0.0 works properly, response_worker will be called

```
response:https://example.com/
```

pyee >= 8.0.0 gives warning, response_worker will not be called
```
pyee/_base.py:81: RuntimeWarning: coroutine 'response_worker' was never awaited
f(*args, **kwargs)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```
