### PR TITLE
fix(browser): Clean up coroutine Browser._targetCreated()

### DIFF
--- a/pyppeteer/browser.py
+++ b/pyppeteer/browser.py
@@ -264,6 +264,9 @@ class Browser(EventEmitter):
     async def disconnect(self) -> None:
         """Disconnect browser."""
         await self._connection.dispose()
+        for target in self._targets.values():
+            if not target._isInitialized:
+                target._initializedCallback(False)
 
     def _getVersion(self) -> Awaitable:
         return self._connection.send('Browser.getVersion')


### PR DESCRIPTION
I use Pyppeteer in production for a few weeks and I notice a lot of logs like
this:
```
Task was destroyed but it is pending!
task: <Task pending name='Task-1222' coro=<Browser._targetCreated() running at
.local/lib/python3.9/site-packages/pyppeteer/browser.py:192> wait_for=<Future
pending cb=[<TaskWakeupMethWrapper object at 0x7f8876b2bac0>()]>>
```

My Python code goes like this:
```py
browser = await pyppeteer.connect(browserURL='http://localhost:9222')
tab = await browser.newPage()
await tab.setContent()
await tab.pdf()
await tab.close()
await browser.disconnect()
```

The error `Task was destroyed but it is pending!` occurs just after
`await browser.disconnect()` and only when I run the above code multiple time
in parallel.

After looking into Pyppeteer and Puppeteer code I understand that they
receive a `targetCreated` event from the CDP for all "targets" running
inside Chromium.
Thus it's possible to receive a `targetCreated` due to a parallel execution
just before `await browser.disconnect()` and never receive the corresponding
`targetInfoChanged`, because the connection is closed.
In that case, the `target._initializedPromise` coroutine never resolve, and
Python log the error `Task was destroyed but it is pending!`.

To fix it I propose to clean un-initialized targets just after closing the
connection to the browser.

I suppose the upstream Puppeteer code doesn't have this issue because Node.js
coroutines are handled differently (but I don't know for sure).