### PR TITLE
Add HTTPException to caught exceptions in launch

### DIFF
--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -9,6 +9,7 @@ from copy import copy
 import json
 from urllib.request import urlopen
 from urllib.error import URLError
+from http.client import HTTPException
 import logging
 import os
 import os.path
@@ -227,8 +228,8 @@ def get_ws_endpoint(url) -> str:
             with urlopen(url) as f:
                 data = json.loads(f.read().decode())
             break
-        except URLError as e:
-            continue
+        except (URLError, HTTPException):
+            pass
         time.sleep(0.1)
 
     return data['webSocketDebuggerUrl']


### PR DESCRIPTION
This PR addresses a common issue that appears in #135 by incorporating the solution suggested by @mk-ship-it in [this comment](https://github.com/pyppeteer/pyppeteer/issues/135#issuecomment-728930052). In his/her words:

> I think I figured this one out after stumbling into it myself. The traceback from @ligou525 includes a reference to this function get_ws_endpoint which turns out to be rather botched. urllib.error.URLError and http.client.HTTPError, base class of BadStatusLine aren't ancestors of each other, albeit urllib incorporates http.client to function. Therefore I added the HTTPError to the caught exceptions in the "hot-patch" approach.