### PR TITLE
[FIX]: Use logging.basicConfig instead of a StreamHandler in pyppeteer/__init__.py

### DIFF
--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -30,7 +30,7 @@ DEBUG = False
 # Setup root logger
 _fmt = '[{levelname[0]}:{name}] {msg}'
 logging.basicConfig(level=logging.DEBUG, format=_fmt)
-_logger = logging.getLogger('pyppeteer')
+_logger = logging.getLogger(__name__)
 _logger.propagate = False
 
 from pyppeteer.launcher import connect, launch, executablePath  # noqa: E402

--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -29,7 +29,7 @@ DEBUG = False
 
 # Setup root logger
 _fmt = '[{levelname[0]}:{name}] {msg}'
-logging.basicConfig(level=logging.DEBUG, format=_fmt)
+logging.basicConfig(level=logging.DEBUG, format=_fmt, style='{')
 _logger = logging.getLogger(__name__)
 _logger.propagate = False
 

--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -28,13 +28,9 @@ __pyppeteer_home__ = os.environ.get(
 DEBUG = False
 
 # Setup root logger
-_logger = logging.getLogger('pyppeteer')
-_log_handler = logging.StreamHandler()
 _fmt = '[{levelname[0]}:{name}] {msg}'
-_formatter = logging.Formatter(fmt=_fmt, style='{')
-_log_handler.setFormatter(_formatter)
-_log_handler.setLevel(logging.DEBUG)
-_logger.addHandler(_log_handler)
+logging.basicConfig(level=logging.DEBUG, format=_fmt)
+_logger = logging.getLogger('pyppeteer')
 _logger.propagate = False
 
 from pyppeteer.launcher import connect, launch, executablePath  # noqa: E402


### PR DESCRIPTION
If I were to import this module and decide to have all my log messages go into a log file rather than STDERR, this module would disobey by using `StreamHandler`. `logging.basicConfig` should be more concise also.