### PR TITLE
Consider using `info` level for download log messages

### DIFF
--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -125,7 +125,7 @@ def extract_zip(data: BytesIO, path: Path) -> None:
     if not exec_path.exists():
         raise IOError('Failed to extract chromium.')
     exec_path.chmod(exec_path.stat().st_mode | stat.S_IXOTH | stat.S_IXGRP | stat.S_IXUSR)
-    logger.warning(f'chromium extracted to: {path}')
+    logger.info(f'chromium extracted to: {path}')
 
 
 def download_chromium() -> None:

--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -67,7 +67,7 @@ def get_url() -> str:
 
 def download_zip(url: str) -> BytesIO:
     """Download data from url."""
-    logger.warning('Starting Chromium download. ' 'Download may take a few minutes.')
+    logger.info('Starting Chromium download. Download may take a few minutes.')
 
     with urllib3.PoolManager(cert_reqs='CERT_REQUIRED', ca_certs=certifi.where()) as http:
         # Get data from url.
@@ -92,7 +92,7 @@ def download_zip(url: str) -> BytesIO:
                 process_bar.update(len(chunk))
             process_bar.close()
 
-    logger.warning('Chromium download done.')
+    logger.info('Chromium download done.')
     return _data
 
 


### PR DESCRIPTION
I'm not sure which is right honestly, but wanted there to be a conversation and make sure this is intentional. Why was this a warning rather than info? Is it not supposed to happen?