### PR TITLE
update puppeteer / chromium deps for debian buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,16 +28,17 @@ jobs:
           keys:
             - poetry_deps_{{checksum "poetry.lock"}}
       - run:
-          name: Install headless Chrome dependancies
+          name: Install headless Chrome dependencies
           # chrome headless libs, see
           # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
           command: |
             sudo apt install -yq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+              ca-certificates fonts-liberation libasound2 libatk1.0-0 \
+              libcairo2 libcups2 libdbus-1-3 libgdk-pixbuf2.0-0 \
+              libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 \
+              libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 \
+              libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+              lsb-release xdg-utils wget 
       - run:
           name: Install tox
           command: pip install tox


### PR DESCRIPTION
Circle CI uses official python docker images. Those docker images uses the latest stable debian release, which has changed from "bullseye" to "buster" earlier in 2021. Some required apt libraries have changed in the latest version.

The proposed changes in this pull request are currently based on a docker image I use in a different project. Let's see if they work on Circle CI as is.