### PR TITLE
Fix an exception when bundling with py2exe

### DIFF
--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
 try:
     __version__ = version(__name__)
 except Exception:
-    __version__ = None
+    __version__ = "0.0.0"
 
 
 __chromium_revision__ = '588429'


### PR DESCRIPTION
The fix #344 did not work completely, since setting `__version__ = None`  in the exception handler will crash when calling ` version.split('.'))`  further down below.

Setting to a dummy `"0.0.0"` fixed it for me