### PR TITLE
Fix Error Running From IIS on Windows

### DIFF
--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -24,7 +24,8 @@ except Exception:
 
 __chromium_revision__ = '588429'
 __base_puppeteer_version__ = 'v1.6.0'
-__pyppeteer_home__ = os.environ.get('PYPPETEER_HOME', AppDirs('pyppeteer').user_data_dir)  # type: str
+__pyppeteer_home__ = os.environ.get('PYPPETEER_HOME')  # type: str
+if not __pyppeteer_home__: __pyppeteer_home__ = AppDirs('pyppeteer').user_data_dir
 DEBUG = False
 
 from pyppeteer.launcher import connect, executablePath, launch, defaultArgs  # noqa: E402; noqa: E402


### PR DESCRIPTION
When running `Pyppeteer` under windows via IIS, it fails because the `AppDirs` scan happens regardless of whether the `PYPPETEER_HOME` environment variable is set or not:

`from pyppeteer import launch` triggers the following Exception:

```
  File "C:\apps\sdk\python\Python38\lib\site-packages\pyppeteer\__init__.py", line 27, in <module>
    __pyppeteer_home__ = os.environ.get('PYPPETEER_HOME', AppDirs('pyppeteer').user_data_dir)  # type: str
  File "C:\apps\sdk\python\Python38\lib\site-packages\appdirs.py", line 419, in user_data_dir
    return user_data_dir(self.appname, self.appauthor,
  File "C:\apps\sdk\python\Python38\lib\site-packages\appdirs.py", line 81, in user_data_dir
    path = os.path.normpath(_get_win_folder(const))
  File "C:\apps\sdk\python\Python38\lib\site-packages\appdirs.py", line 481, in _get_win_folder_with_pywin32
    dir = shell.SHGetFolderPath(0, getattr(shellcon, csidl_name), 0, 0)
pywintypes.com_error: (-2147024891, 'Access is denied.', None, None)
```

Reason for failure: The System user used by IIS does not have a `user_data_dir`. This issue will likely occur for other system processes under windows.