### PR TITLE
Fix BIGINT Page.Events.Console Bug

### DIFF
--- a/pyppeteer/helper.py
+++ b/pyppeteer/helper.py
@@ -86,7 +86,9 @@ def valueFromRemoteObject(remoteObject: Dict) -> Any:
         raise ElementHandleError('Cannot extract value when objectId is given')
     value = remoteObject.get('unserializableValue')
     if value:
-        if value == '-0':
+        if remoteObject.get('type') == 'bigint':
+            return int(value.replace('n', ''))
+        elif value == '-0':
             return -0
         elif value == 'NaN':
             return None


### PR DESCRIPTION
Prevent hanging of `pyppeteer` when code subscribes to  `Page.Events.Console` event and a bigint is logged to the JS Console.

Regarding ticket: https://github.com/puppeteer/puppeteer/pull/4016/files

See Puppeteer PR: https://github.com/puppeteer/puppeteer/pull/4016/files

There may be other PRs that should be considered looking at Puppeteer 4016.