### PR TITLE
Arm support

### DIFF
--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -40,7 +40,7 @@ downloadURLs = {
 }
 
 chromiumExecutable = {
-    'arm_linux': Path('/usr/bin/chromium'),
+    'arm_linux': Path('/usr/bin/chromium-browser'),
     'linux': DOWNLOADS_FOLDER / REVISION / 'chrome-linux' / 'chrome',
     'mac': (DOWNLOADS_FOLDER / REVISION / 'chrome-mac' / 'Chromium.app' / 'Contents' / 'MacOS' / 'Chromium'),
     'win32': DOWNLOADS_FOLDER / REVISION / windowsArchive / 'chrome.exe',

--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -50,7 +50,7 @@ chromiumExecutable = {
 
 def current_platform() -> str:
     """Get current platform name by short string."""
-    if ("system='Linux" and "machine='armv") in str(platform.uname()):
+    if sys.platform.startswith('linux') and platform.uname().machine.startswith('armv'):
         return 'arm_linux'
     elif sys.platform.startswith('linux'):
         return 'linux'

--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import platform
 import stat
 import sys
 from io import BytesIO
@@ -39,6 +40,7 @@ downloadURLs = {
 }
 
 chromiumExecutable = {
+    'arm_linux': Path('/usr/bin/chromium'),
     'linux': DOWNLOADS_FOLDER / REVISION / 'chrome-linux' / 'chrome',
     'mac': (DOWNLOADS_FOLDER / REVISION / 'chrome-mac' / 'Chromium.app' / 'Contents' / 'MacOS' / 'Chromium'),
     'win32': DOWNLOADS_FOLDER / REVISION / windowsArchive / 'chrome.exe',
@@ -48,7 +50,9 @@ chromiumExecutable = {
 
 def current_platform() -> str:
     """Get current platform name by short string."""
-    if sys.platform.startswith('linux'):
+    if ("system='Linux" and "machine='armv") in str(platform.uname()):
+        return 'arm_linux'
+    elif sys.platform.startswith('linux'):
         return 'linux'
     elif sys.platform.startswith('darwin'):
         return 'mac'
@@ -136,7 +140,12 @@ def extract_zip(data: BytesIO, path: Path) -> None:
 
 def download_chromium() -> None:
     """Download and extract chromium."""
-    extract_zip(download_zip(get_url()), DOWNLOADS_FOLDER / REVISION)
+    if current_platform() == 'arm_linux':
+        exec_path = chromium_executable()
+        if not exec_path.exists():
+            logger.warning("Please install chromium via apt-get, eg 'sudo apt-get install chromium'")
+    else:
+        extract_zip(download_zip(get_url()), DOWNLOADS_FOLDER / REVISION)
 
 
 def chromium_excutable() -> Path:

--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -143,7 +143,7 @@ def download_chromium() -> None:
     if current_platform() == 'arm_linux':
         exec_path = chromium_executable()
         if not exec_path.exists():
-            logger.warning("Please install chromium via apt-get, eg 'sudo apt-get install chromium'")
+            logger.warning("Please install chromium via your package manager, eg 'sudo apt-get install chromium'")
     else:
         extract_zip(download_zip(get_url()), DOWNLOADS_FOLDER / REVISION)
 


### PR DESCRIPTION
Enables support for ARM devices. Requires `chromium-browser` to be pre-installed via package manager, e.g. apt. Tested successfully on a Raspberry Pi 3B with Raspberry Pi OS 11 (Bullseye). Resolves #155 .