### PR TITLE
Upgrade to pyee 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ pyppeteer-install = 'pyppeteer.command:install'
 python = "^3.7"
 appdirs = "^1.4.3"
 importlib-metadata = ">=1.4"
-pyee = "^8.1.0"
+pyee = "^9.0.0"
 tqdm = "^4.42.1"
 urllib3 = "^1.25.8"
 websockets = "^10.0"


### PR DESCRIPTION
pyee 9.0.0 has been out for quite a while, and should be fully compatible. The current pin of `^8.1.0` prevents the use of the 9.x series, which causes conflicts with other packages (in my case, I need both pyppeteer and aiortc)