### PR TITLE
Fix async.ensure_future example

### DIFF
--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -870,7 +870,7 @@ function addPageBinding(bindingName) {
 
         .. code::
 
-            navigationPromise = async.ensure_future(page.waitForNavigation())
+            navigationPromise = asyncio.ensure_future(page.waitForNavigation())
             await page.click('a.my-link')  # indirectly cause a navigation
             await navigationPromise  # wait until navigation finishes
 


### PR DESCRIPTION
The documentation gives an example 
```python
navigationPromise = async.ensure_future(page.waitForNavigation())
await page.click('a.my-link')  # indirectly cause a navigation
await navigationPromise  # wait until navigation finishes
```
Upon looking up the [documentation](https://docs.python.org/3/library/asyncio-future.html#asyncio.ensure_future) of asyncio
It seems the correct function to call is `asyncio` not `async`:
```python
navigationPromise = asyncio.ensure_future(page.waitForNavigation())
await page.click('a.my-link')  # indirectly cause a navigation
await navigationPromise  # wait until navigation finishes