### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/pyppeteer/browser.py
+++ b/pyppeteer/browser.py
@@ -36,7 +36,7 @@ class Browser(EventEmitter):
     def __init__(self, connection: Connection, contextIds: List[str],
                  ignoreHTTPSErrors: bool, defaultViewport: Optional[Dict],
                  process: Optional[Popen] = None,
-                 closeCallback: Callable[[], Awaitable[None]] = None,
+                 closeCallback: Optional[Callable[[], Awaitable[None]]] = None,
                  **kwargs: Any) -> None:
         super().__init__()
         self._ignoreHTTPSErrors = ignoreHTTPSErrors
@@ -139,7 +139,7 @@ class Browser(EventEmitter):
     async def create(connection: Connection, contextIds: List[str],
                      ignoreHTTPSErrors: bool, defaultViewport: Optional[Dict],
                      process: Optional[Popen] = None,
-                     closeCallback: Callable[[], Awaitable[None]] = None,
+                     closeCallback: Optional[Callable[[], Awaitable[None]]] = None,
                      **kwargs: Any) -> 'Browser':
         """Create browser object."""
         browser = Browser(connection, contextIds, ignoreHTTPSErrors,

--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -78,7 +78,7 @@ class Connection(EventEmitter):
                 callback.set_result(None)
                 await self.dispose()
 
-    def send(self, method: str, params: dict = None) -> Awaitable:
+    def send(self, method: str, params: Optional[dict] = None) -> Awaitable:
         """Send message via the connection."""
         # Detect connection availability from the second transmission
         if self._lastId and not self._connected:
@@ -207,7 +207,7 @@ class CDPSession(EventEmitter):
         self._sessions: Dict[str, CDPSession] = dict()
         self._loop = loop
 
-    def send(self, method: str, params: dict = None) -> Awaitable:
+    def send(self, method: str, params: Optional[dict] = None) -> Awaitable:
         """Send message to the connected session.
 
         :arg str method: Protocol method name.

--- a/pyppeteer/coverage.py
+++ b/pyppeteer/coverage.py
@@ -5,7 +5,7 @@
 
 from functools import cmp_to_key
 import logging
-from typing import Any, Dict, List
+from typing import Optional, Any, Dict, List
 
 from pyppeteer import helper
 from pyppeteer.connection import CDPSession
@@ -50,7 +50,7 @@ class Coverage(object):
         self._jsCoverage = JSCoverage(client)
         self._cssCoverage = CSSCoverage(client)
 
-    async def startJSCoverage(self, options: Dict = None, **kwargs: Any
+    async def startJSCoverage(self, options: Optional[Dict] = None, **kwargs: Any
                               ) -> None:
         """Start JS coverage measurement.
 
@@ -90,7 +90,7 @@ class Coverage(object):
         """
         return await self._jsCoverage.stop()
 
-    async def startCSSCoverage(self, options: Dict = None, **kwargs: Any
+    async def startCSSCoverage(self, options: Optional[Dict] = None, **kwargs: Any
                                ) -> None:
         """Start CSS coverage measurement.
 
@@ -134,7 +134,7 @@ class JSCoverage(object):
         self._eventListeners: List = list()
         self._resetOnNavigation = False
 
-    async def start(self, options: Dict = None, **kwargs: Any) -> None:
+    async def start(self, options: Optional[Dict] = None, **kwargs: Any) -> None:
         """Start coverage measurement."""
         options = merge_dict(options, kwargs)
         if self._enabled:
@@ -227,7 +227,7 @@ class CSSCoverage(object):
         self._eventListeners: List = []
         self._resetOnNavigation = False
 
-    async def start(self, options: Dict = None, **kwargs: Any) -> None:
+    async def start(self, options: Optional[Dict] = None, **kwargs: Any) -> None:
         """Start coverage measurement."""
         options = merge_dict(options, kwargs)
         if self._enabled:

--- a/pyppeteer/element_handle.py
+++ b/pyppeteer/element_handle.py
@@ -159,7 +159,7 @@ class ElementHandle(JSHandle):
         y = obj.get('y', 0)
         await self._page.mouse.move(x, y)
 
-    async def click(self, options: dict = None, **kwargs: Any) -> None:
+    async def click(self, options: Optional[dict] = None, **kwargs: Any) -> None:
         """Click the center of this element.
 
         If needed, this method scrolls element into view. If the element is
@@ -206,7 +206,7 @@ class ElementHandle(JSHandle):
         await self.executionContext.evaluate(
             'element => element.focus()', self)
 
-    async def type(self, text: str, options: Dict = None, **kwargs: Any
+    async def type(self, text: str, options: Optional[Dict] = None, **kwargs: Any
                    ) -> None:
         """Focus the element and then type text.
 
@@ -216,7 +216,7 @@ class ElementHandle(JSHandle):
         await self.focus()
         await self._page.keyboard.type(text, options)
 
-    async def press(self, key: str, options: Dict = None, **kwargs: Any
+    async def press(self, key: str, options: Optional[Dict] = None, **kwargs: Any
                     ) -> None:
         """Press ``key`` onto the element.
 
@@ -292,7 +292,7 @@ class ElementHandle(JSHandle):
             'height': model.get('height'),
         }
 
-    async def screenshot(self, options: Dict = None, **kwargs: Any) -> bytes:
+    async def screenshot(self, options: Optional[Dict] = None, **kwargs: Any) -> bytes:
         """Take a screenshot of this element.
 
         If the element is detached from DOM, this method raises an

--- a/pyppeteer/execution_context.py
+++ b/pyppeteer/execution_context.py
@@ -30,7 +30,7 @@ class ExecutionContext(object):
     """Execution Context class."""
 
     def __init__(self, client: CDPSession, contextPayload: Dict,
-                 objectHandleFactory: Any, frame: 'Frame' = None) -> None:
+                 objectHandleFactory: Any, frame: Optional['Frame'] = None) -> None:
         self._client = client
         self._frame = frame
         self._contextId = contextPayload.get('id')

--- a/pyppeteer/frame_manager.py
+++ b/pyppeteer/frame_manager.py
@@ -215,7 +215,7 @@ class FrameManager(EventEmitter):
         return context
 
     def createJSHandle(self, context: ExecutionContext,
-                       remoteObject: Dict = None) -> JSHandle:
+                       remoteObject: Optional[Dict] = None) -> JSHandle:
         """Create JS handle associated to the context id and remote object."""
         if remoteObject is None:
             remoteObject = dict()
@@ -571,7 +571,7 @@ function(html) {
         raise ValueError(
             'Provide an object with a `url`, `path` or `content` property')
 
-    async def click(self, selector: str, options: dict = None, **kwargs: Any
+    async def click(self, selector: str, options: Optional[dict] = None, **kwargs: Any
                     ) -> None:
         """Click element which matches ``selector``.
 
@@ -648,7 +648,7 @@ function(html) {
         await handle.tap()
         await handle.dispose()
 
-    async def type(self, selector: str, text: str, options: dict = None,
+    async def type(self, selector: str, text: str, options: Optional[dict] = None,
                    **kwargs: Any) -> None:
         """Type ``text`` on the element which matches ``selector``.
 
@@ -662,7 +662,7 @@ function(html) {
         await handle.dispose()
 
     def waitFor(self, selectorOrFunctionOrTimeout: Union[str, int, float],
-                options: dict = None, *args: Any, **kwargs: Any
+                options: Optional[dict] = None, *args: Any, **kwargs: Any
                 ) -> Union[Awaitable, 'WaitTask']:
         """Wait until `selectorOrFunctionOrTimeout`.
 
@@ -688,7 +688,7 @@ function(html) {
             return self.waitForXPath(selectorOrFunctionOrTimeout, options)
         return self.waitForSelector(selectorOrFunctionOrTimeout, options)
 
-    def waitForSelector(self, selector: str, options: dict = None,
+    def waitForSelector(self, selector: str, options: Optional[dict] = None,
                         **kwargs: Any) -> 'WaitTask':
         """Wait until element which matches ``selector`` appears on page.
 
@@ -697,7 +697,7 @@ function(html) {
         options = merge_dict(options, kwargs)
         return self._waitForSelectorOrXPath(selector, False, options)
 
-    def waitForXPath(self, xpath: str, options: dict = None,
+    def waitForXPath(self, xpath: str, options: Optional[dict] = None,
                      **kwargs: Any) -> 'WaitTask':
         """Wait until element which matches ``xpath`` appears on page.
 
@@ -706,7 +706,7 @@ function(html) {
         options = merge_dict(options, kwargs)
         return self._waitForSelectorOrXPath(xpath, True, options)
 
-    def waitForFunction(self, pageFunction: str, options: dict = None,
+    def waitForFunction(self, pageFunction: str, options: Optional[dict] = None,
                         *args: Any, **kwargs: Any) -> 'WaitTask':
         """Wait until the function completes.
 
@@ -719,7 +719,7 @@ function(html) {
                         self._client._loop, *args)
 
     def _waitForSelectorOrXPath(self, selectorOrXPath: str, isXPath: bool,
-                                options: dict = None, **kwargs: Any
+                                options: Optional[dict] = None, **kwargs: Any
                                 ) -> 'WaitTask':
         options = merge_dict(options, kwargs)
         timeout = options.get('timeout', 30000)

--- a/pyppeteer/input.py
+++ b/pyppeteer/input.py
@@ -4,7 +4,7 @@
 """Keyboard and Mouse module."""
 
 import asyncio
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Optional, Any, Dict, TYPE_CHECKING
 
 from pyppeteer.connection import CDPSession
 from pyppeteer.errors import PyppeteerError
@@ -55,7 +55,7 @@ class Keyboard(object):
         self._modifiers = 0
         self._pressedKeys: Set[str] = set()
 
-    async def down(self, key: str, options: dict = None, **kwargs: Any
+    async def down(self, key: str, options: Optional[dict] = None, **kwargs: Any
                    ) -> None:
         """Dispatch a ``keydown`` event with ``key``.
 
@@ -185,7 +185,7 @@ class Keyboard(object):
         """
         await self._client.send('Input.insertText', {'text': char})
 
-    async def type(self, text: str, options: Dict = None, **kwargs: Any
+    async def type(self, text: str, options: Optional[Dict] = None, **kwargs: Any
                    ) -> None:
         """Type characters into a focused element.
 
@@ -214,7 +214,7 @@ class Keyboard(object):
             if delay:
                 await asyncio.sleep(delay / 1000)
 
-    async def press(self, key: str, options: Dict = None, **kwargs: Any
+    async def press(self, key: str, options: Optional[Dict] = None, **kwargs: Any
                     ) -> None:
         """Press ``key``.
 
@@ -258,7 +258,7 @@ class Mouse(object):
         self._y = 0.0
         self._button = 'none'
 
-    async def move(self, x: float, y: float, options: dict = None,
+    async def move(self, x: float, y: float, options: Optional[dict] = None,
                    **kwargs: Any) -> None:
         """Move mouse cursor (dispatches a ``mousemove`` event).
 
@@ -282,7 +282,7 @@ class Mouse(object):
                 'modifiers': self._keyboard._modifiers,
             })
 
-    async def click(self, x: float, y: float, options: dict = None,
+    async def click(self, x: float, y: float, options: Optional[dict] = None,
                     **kwargs: Any) -> None:
         """Click button at (``x``, ``y``).
 
@@ -303,7 +303,7 @@ class Mouse(object):
             await asyncio.sleep(options.get('delay', 0) / 1000)
         await self.up(options)
 
-    async def down(self, options: dict = None, **kwargs: Any) -> None:
+    async def down(self, options: Optional[dict] = None, **kwargs: Any) -> None:
         """Press down button (dispatches ``mousedown`` event).
 
         This method accepts the following options:
@@ -323,7 +323,7 @@ class Mouse(object):
             'clickCount': options.get('clickCount') or 1,
         })
 
-    async def up(self, options: dict = None, **kwargs: Any) -> None:
+    async def up(self, options: Optional[dict] = None, **kwargs: Any) -> None:
         """Release pressed button (dispatches ``mouseup`` event).
 
         This method accepts the following options:

--- a/pyppeteer/launcher.py
+++ b/pyppeteer/launcher.py
@@ -67,7 +67,7 @@ DEFAULT_ARGS = [
 class Launcher(object):
     """Chrome process launcher class."""
 
-    def __init__(self, options: Dict[str, Any] = None,  # noqa: C901
+    def __init__(self, options: Optional[Dict[str, Any]] = None,  # noqa: C901
                  **kwargs: Any) -> None:
         """Make new launcher."""
         options = merge_dict(options, kwargs)
@@ -236,7 +236,7 @@ def get_ws_endpoint(url) -> str:
     return data['webSocketDebuggerUrl']
 
 
-async def launch(options: dict = None, **kwargs: Any) -> Browser:
+async def launch(options: Optional[dict] = None, **kwargs: Any) -> Browser:
     """Start chrome process and return :class:`~pyppeteer.browser.Browser`.
     This function is a shortcut to :meth:`Launcher(options, **kwargs).launch`.
     Available options are:
@@ -307,7 +307,7 @@ async def launch(options: dict = None, **kwargs: Any) -> Browser:
     return await Launcher(options, **kwargs).launch()
 
 
-async def connect(options: dict = None, **kwargs: Any) -> Browser:
+async def connect(options: Optional[dict] = None, **kwargs: Any) -> Browser:
     """Connect to the existing chrome.
     ``browserWSEndpoint`` or ``browserURL`` option is necessary to connect to
     the chrome. The format of ``browserWSEndpoint`` is
@@ -362,7 +362,7 @@ def executablePath() -> str:
     return str(chromium_executable())
 
 
-def defaultArgs(options: Dict = None, **kwargs: Any) -> List[str]:  # noqa: C901,E501
+def defaultArgs(options: Optional[Dict] = None, **kwargs: Any) -> List[str]:  # noqa: C901,E501
     """Get the default flags the chromium will be launched with.
     ``options`` or keyword arguments are set of configurable options to set on
     the browser. Can have the following fields:

--- a/pyppeteer/navigator_watcher.py
+++ b/pyppeteer/navigator_watcher.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import concurrent.futures
-from typing import Any, Awaitable, Dict, List, Union
+from typing import Optional, Any, Awaitable, Dict, List, Union
 
 from pyppeteer import helper
 from pyppeteer.errors import TimeoutError
@@ -17,7 +17,7 @@ class NavigatorWatcher:
     """NavigatorWatcher class."""
 
     def __init__(self, frameManager: FrameManager, frame: Frame, timeout: int,
-                 options: Dict = None, **kwargs: Any) -> None:
+                 options: Optional[Dict] = None, **kwargs: Any) -> None:
         """Make new navigator watcher."""
         options = merge_dict(options, kwargs)
         self._validate_options(options)
@@ -105,13 +105,13 @@ class NavigatorWatcher:
         """Return navigation promise."""
         return self._navigationPromise
 
-    def _navigatedWithinDocument(self, frame: Frame = None) -> None:
+    def _navigatedWithinDocument(self, frame: Optional[Frame] = None) -> None:
         if frame != self._frame:
             return
         self._hasSameDocumentNavigation = True
         self._checkLifecycleComplete()
 
-    def _checkLifecycleComplete(self, frame: Frame = None) -> None:
+    def _checkLifecycleComplete(self, frame: Optional[Frame] = None) -> None:
         if (self._frame._loaderId == self._initialLoaderId and
                 not self._hasSameDocumentNavigation):
             return

--- a/pyppeteer/network_manager.py
+++ b/pyppeteer/network_manager.py
@@ -226,7 +226,7 @@ class NetworkManager(EventEmitter):
     def _handleRequestRedirect(self, request: 'Request', redirectStatus: int,
                                redirectHeaders: Dict, fromDiskCache: bool,
                                fromServiceWorker: bool,
-                               securityDetails: Dict = None) -> None:
+                               securityDetails: Optional[Dict] = None) -> None:
         response = Response(self._client, request, redirectStatus,
                             redirectHeaders, fromDiskCache, fromServiceWorker,
                             securityDetails)
@@ -427,7 +427,7 @@ class Request(object):
             return None
         return {'errorText': self._failureText}
 
-    async def continue_(self, overrides: Dict = None) -> None:
+    async def continue_(self, overrides: Optional[Dict] = None) -> None:
         """Continue request with optional request overrides.
 
         To use this method, request interception should be enabled by
@@ -589,7 +589,7 @@ class Response(object):
 
     def __init__(self, client: CDPSession, request: Request, status: int,
                  headers: Dict[str, str], fromDiskCache: bool,
-                 fromServiceWorker: bool, securityDetails: Dict = None
+                 fromServiceWorker: bool, securityDetails: Optional[Dict] = None
                  ) -> None:
         self._client = client
         self._request = request

--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -88,7 +88,7 @@ class Page(EventEmitter):
         target: 'Target',
         ignoreHTTPSErrors: bool,
         defaultViewport: Optional[Dict],
-        screenshotTaskQueue: list = None,
+        screenshotTaskQueue: Optional[list] = None,
     ) -> 'Page':
         """Async function which makes new page object."""
         await client.send('Page.enable'),
@@ -116,7 +116,7 @@ class Page(EventEmitter):
         target: 'Target',  # noqa: C901
         frameTree: Dict,
         ignoreHTTPSErrors: bool,
-        screenshotTaskQueue: list = None,
+        screenshotTaskQueue: Optional[list] = None,
     ) -> None:
         super().__init__()
         self._closed = False
@@ -519,7 +519,7 @@ class Page(EventEmitter):
         if items:
             await self._client.send('Network.setCookies', {'cookies': items,})
 
-    async def addScriptTag(self, options: Dict = None, **kwargs: str) -> ElementHandle:
+    async def addScriptTag(self, options: Optional[Dict] = None, **kwargs: str) -> ElementHandle:
         """Add script tag to this page.
 
         One of ``url``, ``path`` or ``content`` option is necessary.
@@ -538,7 +538,7 @@ class Page(EventEmitter):
         options = merge_dict(options, kwargs)
         return await frame.addScriptTag(options)
 
-    async def addStyleTag(self, options: Dict = None, **kwargs: str) -> ElementHandle:
+    async def addStyleTag(self, options: Optional[Dict] = None, **kwargs: str) -> ElementHandle:
         """Add style or link tag to this page.
 
         One of ``url``, ``path`` or ``content`` option is necessary.
@@ -770,7 +770,7 @@ function addPageBinding(bindingName) {
             raise PageError('No main frame.')
         await frame.setContent(html)
 
-    async def goto(self, url: str, options: dict = None, **kwargs: Any) -> Optional[Response]:
+    async def goto(self, url: str, options: Optional[dict] = None, **kwargs: Any) -> Optional[Response]:
         """Go to the ``url``.
 
         :arg string url: URL to navigate page to. The url should include
@@ -845,7 +845,7 @@ function addPageBinding(bindingName) {
             return f'{response["errorText"]} at {url}'
         return None
 
-    async def reload(self, options: dict = None, **kwargs: Any) -> Optional[Response]:
+    async def reload(self, options: Optional[dict] = None, **kwargs: Any) -> Optional[Response]:
         """Reload this page.
 
         Available options are same as :meth:`goto` method.
@@ -854,7 +854,7 @@ function addPageBinding(bindingName) {
         response = (await asyncio.gather(self.waitForNavigation(options), self._client.send('Page.reload'),))[0]
         return response
 
-    async def waitForNavigation(self, options: dict = None, **kwargs: Any) -> Optional[Response]:
+    async def waitForNavigation(self, options: Optional[dict] = None, **kwargs: Any) -> Optional[Response]:
         """Wait for navigation.
 
         Available options are same as :meth:`goto` method.
@@ -909,7 +909,7 @@ function addPageBinding(bindingName) {
         return response
 
     async def waitForRequest(
-        self, urlOrPredicate: Union[str, Callable[[Request], bool]], options: Dict = None, **kwargs: Any  # noqa: E501
+        self, urlOrPredicate: Union[str, Callable[[Request], bool]], options: Optional[Dict] = None, **kwargs: Any  # noqa: E501
     ) -> Request:
         """Wait for request.
 
@@ -943,7 +943,7 @@ function addPageBinding(bindingName) {
         )
 
     async def waitForResponse(
-        self, urlOrPredicate: Union[str, Callable[[Response], bool]], options: Dict = None, **kwargs: Any  # noqa: E501
+        self, urlOrPredicate: Union[str, Callable[[Response], bool]], options: Optional[Dict] = None, **kwargs: Any  # noqa: E501
     ) -> Response:
         """Wait for response.
 
@@ -976,7 +976,7 @@ function addPageBinding(bindingName) {
             self._networkManager, NetworkManager.Events.Response, predicate, timeout, self._client._loop,
         )
 
-    async def goBack(self, options: dict = None, **kwargs: Any) -> Optional[Response]:
+    async def goBack(self, options: Optional[dict] = None, **kwargs: Any) -> Optional[Response]:
         """Navigate to the previous page in history.
 
         Available options are same as :meth:`goto` method.
@@ -986,7 +986,7 @@ function addPageBinding(bindingName) {
         options = merge_dict(options, kwargs)
         return await self._go(-1, options)
 
-    async def goForward(self, options: dict = None, **kwargs: Any) -> Optional[Response]:
+    async def goForward(self, options: Optional[dict] = None, **kwargs: Any) -> Optional[Response]:
         """Navigate to the next page in history.
 
         Available options are same as :meth:`goto` method.
@@ -1015,7 +1015,7 @@ function addPageBinding(bindingName) {
         """Bring page to front (activate tab)."""
         await self._client.send('Page.bringToFront')
 
-    async def emulate(self, options: dict = None, **kwargs: Any) -> None:
+    async def emulate(self, options: Optional[dict] = None, **kwargs: Any) -> None:
         """Emulate given device metrics and user agent.
 
         This method is a shortcut for calling two methods:
@@ -1063,7 +1063,7 @@ function addPageBinding(bindingName) {
         """
         await self._client.send('Page.setBypassCSP', {'enabled': enabled})
 
-    async def emulateMedia(self, mediaType: str = None) -> None:
+    async def emulateMedia(self, mediaType: Optional[str] = None) -> None:
         """Emulate css media type of the page.
 
         :arg str mediaType: Changes the CSS media type of the page. The only
@@ -1134,7 +1134,7 @@ function addPageBinding(bindingName) {
         """
         await self._client.send('Network.setCacheDisabled', {'cacheDisabled': not enabled})
 
-    async def screenshot(self, options: dict = None, **kwargs: Any) -> Union[bytes, str]:
+    async def screenshot(self, options: Optional[dict] = None, **kwargs: Any) -> Union[bytes, str]:
         """Take a screen shot.
 
         The following options are available:
@@ -1245,7 +1245,7 @@ function addPageBinding(bindingName) {
                 f.write(buffer)
         return buffer
 
-    async def pdf(self, options: dict = None, **kwargs: Any) -> bytes:
+    async def pdf(self, options: Optional[dict] = None, **kwargs: Any) -> bytes:
         """Generate a pdf of the page.
 
         Options:
@@ -1407,7 +1407,7 @@ function addPageBinding(bindingName) {
             raise PageError('no main frame.')
         return await frame.title()
 
-    async def close(self, options: Dict = None, **kwargs: Any) -> None:
+    async def close(self, options: Optional[Dict] = None, **kwargs: Any) -> None:
         """Close this page.
 
         Available options:
@@ -1443,7 +1443,7 @@ function addPageBinding(bindingName) {
         """Get :class:`~pyppeteer.input.Mouse` object."""
         return self._mouse
 
-    async def click(self, selector: str, options: dict = None, **kwargs: Any) -> None:
+    async def click(self, selector: str, options: Optional[dict] = None, **kwargs: Any) -> None:
         """Click element which matches ``selector``.
 
         This method fetches an element with ``selector``, scrolls it into view
@@ -1504,7 +1504,7 @@ function addPageBinding(bindingName) {
             raise PageError('no main frame.')
         return await frame.select(selector, *values)
 
-    async def type(self, selector: str, text: str, options: dict = None, **kwargs: Any) -> None:
+    async def type(self, selector: str, text: str, options: Optional[dict] = None, **kwargs: Any) -> None:
         """Type ``text`` on the element which matches ``selector``.
 
         If no element matched the ``selector``, raise ``PageError``.
@@ -1517,7 +1517,7 @@ function addPageBinding(bindingName) {
         return await frame.type(selector, text, options, **kwargs)
 
     def waitFor(
-        self, selectorOrFunctionOrTimeout: Union[str, int, float], options: dict = None, *args: Any, **kwargs: Any
+        self, selectorOrFunctionOrTimeout: Union[str, int, float], options: Optional[dict] = None, *args: Any, **kwargs: Any
     ) -> Awaitable:
         """Wait for function, timeout, or element which matches on page.
 
@@ -1551,7 +1551,7 @@ function addPageBinding(bindingName) {
             raise PageError('no main frame.')
         return frame.waitFor(selectorOrFunctionOrTimeout, options, *args, **kwargs)
 
-    def waitForSelector(self, selector: str, options: dict = None, **kwargs: Any) -> Awaitable:
+    def waitForSelector(self, selector: str, options: Optional[dict] = None, **kwargs: Any) -> Awaitable:
         """Wait until element which matches ``selector`` appears on page.
 
         Wait for the ``selector`` to appear in page. If at the moment of
@@ -1579,7 +1579,7 @@ function addPageBinding(bindingName) {
             raise PageError('no main frame.')
         return frame.waitForSelector(selector, options, **kwargs)
 
-    def waitForXPath(self, xpath: str, options: dict = None, **kwargs: Any) -> Awaitable:
+    def waitForXPath(self, xpath: str, options: Optional[dict] = None, **kwargs: Any) -> Awaitable:
         """Wait until element which matches ``xpath`` appears on page.
 
         Wait for the ``xpath`` to appear in page. If the moment of calling the
@@ -1608,7 +1608,7 @@ function addPageBinding(bindingName) {
             raise PageError('no main frame.')
         return frame.waitForXPath(xpath, options, **kwargs)
 
-    def waitForFunction(self, pageFunction: str, options: dict = None, *args: str, **kwargs: Any) -> Awaitable:
+    def waitForFunction(self, pageFunction: str, options: Optional[dict] = None, *args: str, **kwargs: Any) -> Awaitable:
         """Wait until the function completes and returns a truthy value.
 
         :arg Any args: Arguments to pass to ``pageFunction``.
@@ -1689,7 +1689,7 @@ class ConsoleMessage(object):
     ConsoleMessage objects are dispatched by page via the ``console`` event.
     """
 
-    def __init__(self, type: str, text: str, args: List[JSHandle] = None) -> None:
+    def __init__(self, type: str, text: str, args: Optional[List[JSHandle]] = None) -> None:
         #: (str) type of console message
         self._type = type
         #: (str) console message string

--- a/pyppeteer/tracing.py
+++ b/pyppeteer/tracing.py
@@ -4,7 +4,7 @@
 """Tracing module."""
 
 from pathlib import Path
-from typing import Any
+from typing import Optional, Any
 
 from pyppeteer.connection import CDPSession
 from pyppeteer.util import merge_dict
@@ -29,7 +29,7 @@ class Tracing(object):
         self._recording = False
         self._path = ''
 
-    async def start(self, options: dict = None, **kwargs: Any) -> None:
+    async def start(self, options: Optional[dict] = None, **kwargs: Any) -> None:
         """Start tracing.
 
         Only one trace can be active at a time per browser.

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ disallow_untyped_defs = true
 disallow_untyped_calls = true
 follow_imports = silent
 ignore_missing_imports = true
+no_implicit_optional = true
 mypy_path = out
 
 [mypy-pyppeteer.tests.*,pyppeteer.docs.*]


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/hauntsaninja/no_implicit_optional
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401