### PR TITLE
Hotfix KeyError which is not expected but garanteeed by mistake

### DIFF
--- a/pyppeteer/connection.py
+++ b/pyppeteer/connection.py
@@ -235,8 +235,8 @@ class CDPSession(EventEmitter):
         except Exception as e:
             # The response from target might have been already dispatched
             if _id in self._callbacks:
-                del self._callbacks[_id]
                 _callback = self._callbacks[_id]
+                del self._callbacks[_id]
                 _callback.set_exception(_rewriteError(
                     _callback.error,  # type: ignore
                     e.args[0],


### PR DESCRIPTION
Stack like this was generated by code I fixed. 
Expected behaviour here "push real exception up", 
but  KeyError exception was pushed instead.

```
KeyError: 1547
_callback = self._callbacks[_id]
File "/usr/local/lib/python3.8/site-packages/pyppeteer/connection.py", line 239 send
```