### PR TITLE
Fix deprecated usage of asyncio wait in page.py line 610

### DIFF
--- a/pyppeteer/page.py
+++ b/pyppeteer/page.py
@@ -607,7 +607,8 @@ function addPageBinding(bindingName) {
             except Exception as e:
                 debugError(logger, e)
 
-        await asyncio.wait([_evaluate(frame, expression) for frame in self.frames])
+        loop = asyncio.get_event_loop()
+        await asyncio.wait([loop.create_task(_evaluate(frame, expression)) for frame in self.frames])
 
     async def authenticate(self, credentials: Dict[str, str]) -> Any:
         """Provide credentials for http authentication.


### PR DESCRIPTION
This Bug led to `TypeError: Passing coroutines is forbidden, use tasks explicitly.` Exception.
The fix was proposed by @aont and works for me (Python 3.11.2, Pyppeteer 1.0.2)
https://github.com/pyppeteer/pyppeteer/issues/443