### PR TITLE
fix: AttributeError: 'NoneType' object has no attribute 'split'

### DIFF
--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -30,7 +30,7 @@ DEBUG = False
 from pyppeteer.launcher import connect, executablePath, launch, defaultArgs  # noqa: E402; noqa: E402
 
 version = __version__
-version_info = tuple(int(i) for i in version.split('.'))
+version_info = tuple(int(i) for i in version.split('.')) if version != None else (0, 0, 0)
 
 __all__ = [
     'connect',


### PR DESCRIPTION
make pyppeteer run from source
