### PR TITLE
Platform specific chromium revision download

### DIFF
--- a/pyppeteer/__init__.py
+++ b/pyppeteer/__init__.py
@@ -17,7 +17,12 @@ except Exception:
 
 
 # old chrome version panic upon launching - this one may not match the base puppeteer version, but at least it launches
-__chromium_revision__ = '1181205'
+__chromium_revisions__ = {
+'linux': '1300930',
+'mac': '1300885',
+'win32': '1300886',
+'win64': '1300870',
+}
 __base_puppeteer_version__ = 'v1.6.0'
 __pyppeteer_home__ = os.environ.get('PYPPETEER_HOME', AppDirs('pyppeteer').user_data_dir)  # type: str
 DEBUG = False

--- a/pyppeteer/chromium_downloader.py
+++ b/pyppeteer/chromium_downloader.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 
 import certifi
 import urllib3
-from pyppeteer import __chromium_revision__, __pyppeteer_home__
+from pyppeteer import __chromium_revisions__, __pyppeteer_home__
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,20 @@ DEFAULT_DOWNLOAD_HOST = 'https://storage.googleapis.com'
 DOWNLOAD_HOST = os.environ.get('PYPPETEER_DOWNLOAD_HOST', DEFAULT_DOWNLOAD_HOST)
 BASE_URL = f'{DOWNLOAD_HOST}/chromium-browser-snapshots'
 
-REVISION = os.environ.get('PYPPETEER_CHROMIUM_REVISION', __chromium_revision__)
+def current_platform() -> str:
+    """Get current platform name by short string."""
+    platform = sys.platform
+    if platform.startswith('linux'):
+        return 'linux'
+    elif platform.startswith('darwin'):
+        return 'mac'
+    elif platform.startswith('win') or platform.startswith('msys') or platform.startswith('cyg'):
+        if sys.maxsize > 2 ** 31 - 1:
+            return 'win64'
+        return 'win32'
+    raise OSError('Unsupported platform: ' + platform)
+
+REVISION = os.environ.get('PYPPETEER_CHROMIUM_REVISION', __chromium_revisions__[current_platform()])
 
 NO_PROGRESS_BAR = os.environ.get('PYPPETEER_NO_PROGRESS_BAR', '')
 if NO_PROGRESS_BAR.lower() in ('1', 'true'):
@@ -50,20 +63,6 @@ chromiumExecutable = {
     'win32': DOWNLOADS_FOLDER / REVISION / windowsArchive / 'chrome.exe',
     'win64': DOWNLOADS_FOLDER / REVISION / windowsArchive / 'chrome.exe',
 }
-
-
-def current_platform() -> str:
-    """Get current platform name by short string."""
-    if sys.platform.startswith('linux'):
-        return 'linux'
-    elif sys.platform.startswith('darwin'):
-        return 'mac'
-    elif sys.platform.startswith('win') or sys.platform.startswith('msys') or sys.platform.startswith('cyg'):
-        if sys.maxsize > 2 ** 31 - 1:
-            return 'win64'
-        return 'win32'
-    raise OSError('Unsupported platform: ' + sys.platform)
-
 
 def get_url() -> str:
     """Get chromium download url."""


### PR DESCRIPTION
This is to address #464.
This PR makes it so the revision number of chromium will be platform-specific, instead of just one "universal" revision, since the revision currently used does not exist for Windows.
this also means I used the latest revisions for each platform